### PR TITLE
Qsearch in-check evasion handling

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -151,37 +151,56 @@ int Search::qsearch(int alpha, int beta, ThreadData& thread, Stack* ss) {
         return board->eval();
     }
 
-    auto rawEval  = (ttStaticEval != SCORE_NONE) ? ttStaticEval : board->eval();
-    auto standPat = adjustEvalWithCorrHist(thread, ss, rawEval);
+    bool inCheck = board->inCheck();
 
-    if(!ttHit)
-        TT::Instance()->ttSave(board->key, ss->ply, SCORE_NONE, rawEval,TT_NONE , 0, NO_MOVE);
+    auto rawEval = (ttStaticEval != SCORE_NONE) ? ttStaticEval : board->eval();
 
-    //ttValue can be used as a better position evaluation
-    if (ttHit && (ttBound & (ttScore > standPat ? TT_LOWERBOUND : TT_UPPERBOUND)))
-    {
-        standPat = ttScore;
-    }
+    if (!ttHit)
+        TT::Instance()->ttSave(board->key, ss->ply, SCORE_NONE, rawEval, TT_NONE, 0, NO_MOVE);
 
-    if (standPat >= beta)
-    {
-        return standPat;
-    }
-    if (alpha < standPat)
-    {
-        alpha = standPat;
-    }
-
-    int      bestScore = standPat, score;
+    int      bestScore, score;
     uint16_t move, bestMove = NO_MOVE;
 
+    if (inCheck)
+    {
+        // When in check we cannot trust the static eval: search all evasions.
+        bestScore = -VALUE_INFINITE;
+    }
+    else
+    {
+        auto standPat = adjustEvalWithCorrHist(thread, ss, rawEval);
+
+        //ttValue can be used as a better position evaluation
+        if (ttHit && (ttBound & (ttScore > standPat ? TT_LOWERBOUND : TT_UPPERBOUND)))
+        {
+            standPat = ttScore;
+        }
+
+        if (standPat >= beta)
+        {
+            return standPat;
+        }
+        if (alpha < standPat)
+        {
+            alpha = standPat;
+        }
+        bestScore = standPat;
+    }
+
     auto moveList = MoveList(ttMove, true);
-    legalmoves<TACTICAL_MOVES>(*board, moveList);
+    if (inCheck)
+        legalmoves<ALL_MOVES>(*board, moveList);
+    else
+        legalmoves<TACTICAL_MOVES>(*board, moveList);
+
+    // checkmate
+    if (inCheck && moveList.numMove == 0)
+        return -(MAX_MATE_SCORE - ss->ply);
 
     while ((move = moveList.pickMove(thread, ss)))
     {
 
-        if (move != ttMove && !SEE(*board, move))
+        if (!inCheck && move != ttMove && !SEE(*board, move))
             continue;
         ss->move = move;
         board->makeMove(move);

--- a/src/types.h
+++ b/src/types.h
@@ -17,7 +17,7 @@
 #include <bitset>
 
 #ifndef VERSION
-    #define VERSION "6.44"
+    #define VERSION "6.45"
 #endif
 
 constexpr auto MAX_PLY   = 100;


### PR DESCRIPTION
When in check, qsearch previously stood pat on a meaningless static eval and only generated tactical moves, so quiet evasions were never tried and in-check leaf scores were systematically wrong.

Now, when in check: skip the stand-pat cutoff (bestScore = -inf), generate all legal evasions, do not SEE-prune them, and return a mate score when no evasion exists.

Elo   | 6.03 +- 3.25 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 11746 W: 2957 L: 2753 D: 6036
Penta | [32, 1325, 2974, 1491, 51]

Bench 2432017

