### PR TITLE
Threat Inputs NNUE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,13 +2,18 @@
 CXX      = g++
 LIBS     = -lm
 # Named after the first 12 hex of its sha256. Override with NETWORK=<file>.
-NETWORK ?= devre-6e8b27f4e26d.bin
+NETWORK ?= devre-a064d8d9d7b6.bin
 
-M64     = -m64 -mpopcnt
-MSSE2   = $(M64) -msse -msse2
-MSSSE3  = $(MSSE2) -mssse3
-MAVX2   = $(MSSSE3) -msse4.1 -mbmi -mfma -mavx2
-MAVX512 = $(MAVX2) -mavx512f -mavx512bw
+# ISA levels, each a superset of the one above. SSE2 is the floor: simd.h has a
+# full path for it, so every level below builds and evaluates identically -- only
+# the speed changes. VNNI folds the NNUE head's maddubs+madd+add into one
+# instruction and is worth having on Zen 4 / Ice Lake and later.
+M64        = -m64 -mpopcnt
+MSSE2      = $(M64) -msse -msse2
+MSSSE3     = $(MSSE2) -mssse3
+MAVX2      = $(MSSSE3) -msse4.1 -mbmi -mfma -mavx2
+MAVX512    = $(MAVX2) -mavx512f -mavx512bw
+MVNNI512   = $(MAVX512) -mavx512dq -mavx512vl -mavx512vnni
 
 FILES = *.cpp datagen/*.cpp fathom/src/tbprobe.c
 
@@ -29,15 +34,21 @@ ifeq ($(build),)
 endif
 
 ifeq ($(build), native)
-    CXX_FLAGS += -march=native
-else ifeq ($(findstring sse2, $(build)), sse2)
-	CXX_FLAGS += $(MSSE2)
-else ifeq ($(findstring ssse3, $(build)), ssse3)
-	CXX_FLAGS += $(MSSSE3)
-else ifeq ($(findstring avx2, $(build)), avx2)
-	CXX_FLAGS += $(MAVX2)
+	CXX_FLAGS += -march=native
+else ifeq ($(findstring vnni512, $(build)), vnni512)
+	CXX_FLAGS += $(MVNNI512)
 else ifeq ($(findstring avx512, $(build)), avx512)
 	CXX_FLAGS += $(MAVX512)
+else ifeq ($(findstring avx2, $(build)), avx2)
+	CXX_FLAGS += $(MAVX2)
+else ifeq ($(findstring ssse3, $(build)), ssse3)
+	CXX_FLAGS += $(MSSSE3)
+else ifeq ($(findstring sse2, $(build)), sse2)
+	CXX_FLAGS += $(MSSE2)
+else
+	# Still builds and plays identically, just at the slowest ISA level.
+	$(warning unrecognised build=$(build); falling back to sse2. Known: native, vnni512, avx512, avx2, ssse3, sse2, each optionally suffixed -pext)
+	CXX_FLAGS += $(MSSE2)
 endif
 
 ifeq ($(build), native)

--- a/src/attack.h
+++ b/src/attack.h
@@ -51,7 +51,7 @@ static const uint64_t rookMagics[] = {
   0x00FFFCDDFCED714AULL, 0x007FFCDDFCED714AULL, 0x003FFFCDFFD88096ULL, 0x0000040810002101ULL, 0x0001000204080011ULL, 0x0001000204000801ULL, 0x0001000082000401ULL, 0x0001FFFAABFAD1A2ULL};
 
 //pre-calculated attacks for pawns, knight and king
-static const uint64_t KingAttacks[64] = {
+inline constexpr uint64_t KingAttacks[64] = {
   0x0000000000000302ULL, 0x0000000000000705ULL, 0x0000000000000e0aULL, 0x0000000000001c14ULL, 0x0000000000003828ULL, 0x0000000000007050ULL, 0x000000000000e0a0ULL, 0x000000000000c040ULL,
   0x0000000000030203ULL, 0x0000000000070507ULL, 0x00000000000e0a0eULL, 0x00000000001c141cULL, 0x0000000000382838ULL, 0x0000000000705070ULL, 0x0000000000e0a0e0ULL, 0x0000000000c040c0ULL,
   0x0000000003020300ULL, 0x0000000007050700ULL, 0x000000000e0a0e00ULL, 0x000000001c141c00ULL, 0x0000000038283800ULL, 0x0000000070507000ULL, 0x00000000e0a0e000ULL, 0x00000000c040c000ULL,
@@ -61,7 +61,7 @@ static const uint64_t KingAttacks[64] = {
   0x0302030000000000ULL, 0x0705070000000000ULL, 0x0e0a0e0000000000ULL, 0x1c141c0000000000ULL, 0x3828380000000000ULL, 0x7050700000000000ULL, 0xe0a0e00000000000ULL, 0xc040c00000000000ULL,
   0x0203000000000000ULL, 0x0507000000000000ULL, 0x0a0e000000000000ULL, 0x141c000000000000ULL, 0x2838000000000000ULL, 0x5070000000000000ULL, 0xa0e0000000000000ULL, 0x40c0000000000000ULL};
 
-static const uint64_t KnightAttacks[64] = {
+inline constexpr uint64_t KnightAttacks[64] = {
   0x0000000000020400ULL, 0x0000000000050800ULL, 0x00000000000a1100ULL, 0x0000000000142200ULL, 0x0000000000284400ULL, 0x0000000000508800ULL, 0x0000000000a01000ULL, 0x0000000000402000ULL,
   0x0000000002040004ULL, 0x0000000005080008ULL, 0x000000000a110011ULL, 0x0000000014220022ULL, 0x0000000028440044ULL, 0x0000000050880088ULL, 0x00000000a0100010ULL, 0x0000000040200020ULL,
   0x0000000204000402ULL, 0x0000000508000805ULL, 0x0000000a1100110aULL, 0x0000001422002214ULL, 0x0000002844004428ULL, 0x0000005088008850ULL, 0x000000a0100010a0ULL, 0x0000004020002040ULL,
@@ -70,7 +70,7 @@ static const uint64_t KnightAttacks[64] = {
   0x0204000402000000ULL, 0x0508000805000000ULL, 0x0a1100110a000000ULL, 0x1422002214000000ULL, 0x2844004428000000ULL, 0x5088008850000000ULL, 0xa0100010a0000000ULL, 0x4020002040000000ULL,
   0x0400040200000000ULL, 0x0800080500000000ULL, 0x1100110a00000000ULL, 0x2200221400000000ULL, 0x4400442800000000ULL, 0x8800885000000000ULL, 0x100010a000000000ULL, 0x2000204000000000ULL,
   0x0004020000000000ULL, 0x0008050000000000ULL, 0x00110a0000000000ULL, 0x0022140000000000ULL, 0x0044280000000000ULL, 0x0088500000000000ULL, 0x0010a00000000000ULL, 0x0020400000000000ULL};
-static const uint64_t PawnAttacks[2][64] = {
+inline constexpr uint64_t PawnAttacks[2][64] = {
   {0x0000000000000200ULL, 0x0000000000000500ULL, 0x0000000000000a00ULL, 0x0000000000001400ULL, 0x0000000000002800ULL, 0x0000000000005000ULL, 0x000000000000a000ULL, 0x0000000000004000ULL,
    0x0000000000020000ULL, 0x0000000000050000ULL, 0x00000000000a0000ULL, 0x0000000000140000ULL, 0x0000000000280000ULL, 0x0000000000500000ULL, 0x0000000000a00000ULL, 0x0000000000400000ULL,
    0x0000000002000000ULL, 0x0000000005000000ULL, 0x000000000a000000ULL, 0x0000000014000000ULL, 0x0000000028000000ULL, 0x0000000050000000ULL, 0x00000000a0000000ULL, 0x0000000040000000ULL,
@@ -201,5 +201,49 @@ bool isSquareAttacked(Board& board, int sq, int side);
 uint64_t squareAttackedBy(Board& board, int square);
 
 int getLeastValuableAttacker(Board& board, uint64_t attackers, int side);
+
+struct DirectionRays {
+    uint64_t north[64]{};
+    uint64_t south[64]{};
+    uint64_t east[64]{};
+    uint64_t west[64]{};
+    uint64_t north_east[64]{};
+    uint64_t south_west[64]{};
+    uint64_t north_west[64]{};
+    uint64_t south_east[64]{};
+    // Empty-board rays: a slider can only reach sq from one of these.
+    uint64_t diag[64]{};
+    uint64_t straight[64]{};
+
+    constexpr DirectionRays() {
+        for (int sq = 0; sq < 64; sq++) {
+            int r = sq / 8;
+            int f = sq % 8;
+            for (int s2 = 0; s2 < 64; s2++) {
+                if (sq == s2) continue;
+                int r2 = s2 / 8;
+                int f2 = s2 % 8;
+                uint64_t bit = 1ULL << s2;
+                if (f == f2) {
+                    if (r2 > r) north[sq] |= bit;
+                    else south[sq] |= bit;
+                } else if (r == r2) {
+                    if (f2 > f) east[sq] |= bit;
+                    else west[sq] |= bit;
+                } else if (r2 - r == f2 - f) {
+                    if (r2 > r) north_east[sq] |= bit;
+                    else south_west[sq] |= bit;
+                } else if (r2 - r == -(f2 - f)) {
+                    if (r2 > r) north_west[sq] |= bit;
+                    else south_east[sq] |= bit;
+                }
+            }
+            diag[sq]     = north_east[sq] | south_west[sq] | north_west[sq] | south_east[sq];
+            straight[sq] = north[sq] | south[sq] | east[sq] | west[sq];
+        }
+    }
+};
+
+inline constexpr DirectionRays DIR_RAYS{};
 
 #endif  //DEVRE_ATTACK_H

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -132,12 +132,179 @@ Board::Board(const std::string& fen) {
     nnueData.accumulator[0].clear();
 }
 
-void Board::addPiece(int piece, int sq) {
+void Board::updateThreatsForPiece(int piece, int sq, int sign) {
+    if (piece == EMPTY) return;
+    auto& acc = nnueData.accumulator[nnueData.size];
+    int pType = pieceType(piece);
+    int pCol  = pieceColor(piece);
+    uint64_t occ = occupied[WHITE] | occupied[BLACK];
+
+    uint64_t bAtt = 0;
+    uint64_t rAtt = 0;
+    bool bAttComputed = false;
+    bool rAttComputed = false;
+
+    auto getBAtt = [&]() -> uint64_t {
+        if (!bAttComputed) {
+            bAtt = bishopAttacks(occ, sq);
+            bAttComputed = true;
+        }
+        return bAtt;
+    };
+
+    auto getRAtt = [&]() -> uint64_t {
+        if (!rAttComputed) {
+            rAtt = rookAttacks(occ, sq);
+            rAttComputed = true;
+        }
+        return rAtt;
+    };
+    
+    if (pType == KING) return; // King is never a threat target
+
+    // 1. Outgoing threats: pieces attacked by this piece. Only the target mask
+    // differs per piece type; the feature space has no threat onto a king, and
+    // none from a bishop or rook onto a queen.
+    const uint64_t kings = bitboards[WHITE_KING] | bitboards[BLACK_KING];
+    uint64_t       attacked = 0;
+    switch (pType)
+    {
+    case PAWN :
+        attacked = PawnAttacks[pCol][sq] & (bitboards[WHITE_KNIGHT] | bitboards[BLACK_KNIGHT]
+                                            | bitboards[WHITE_ROOK] | bitboards[BLACK_ROOK]);
+        break;
+    case KNIGHT :
+        attacked = KnightAttacks[sq] & occ & ~kings;
+        break;
+    case BISHOP :
+        attacked = getBAtt() & occ & ~(kings | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]);
+        break;
+    case ROOK :
+        attacked = getRAtt() & occ & ~(kings | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]);
+        break;
+    case QUEEN :
+        attacked = (getBAtt() | getRAtt()) & occ & ~kings;
+        break;
+    default :
+        break;
+    }
+
+    while (attacked)
+    {
+        const int dest   = poplsb(attacked);
+        const int victim = pieceBoard[dest];
+        acc.addThreatChange(pType, pCol, pieceType(victim), pieceColor(victim), sq, dest, sign);
+    }
+
+    // Pawns attacking sq (only if target is Knight or Rook)
+    if (pType == KNIGHT || pType == ROOK) {
+        uint64_t whitePawnAtt = PawnAttacks[BLACK][sq] & bitboards[WHITE_PAWN];
+        while (whitePawnAtt) {
+            int attSq = poplsb(whitePawnAtt);
+            acc.addThreatChange(
+                PAWN, WHITE, pType, pCol, attSq, sq, sign);
+        }
+        uint64_t blackPawnAtt = PawnAttacks[WHITE][sq] & bitboards[BLACK_PAWN];
+        while (blackPawnAtt) {
+            int attSq = poplsb(blackPawnAtt);
+            acc.addThreatChange(
+                PAWN, BLACK, pType, pCol, attSq, sq, sign);
+        }
+    }
+
+    // Knights attacking sq
+    uint64_t knightAtt = KnightAttacks[sq] & (bitboards[WHITE_KNIGHT] | bitboards[BLACK_KNIGHT]);
+    while (knightAtt) {
+        int attSq = poplsb(knightAtt);
+        int attCol = pieceColor(pieceBoard[attSq]);
+        acc.addThreatChange(
+            KNIGHT, attCol, pType, pCol, attSq, sq, sign);
+    }
+
+    // Diagonal sliders attacking sq. No bishop->queen threat exists, so a queen
+    // victim narrows the attackers to queens.
+    {
+        uint64_t sliders = (pType != QUEEN)
+                             ? bitboards[WHITE_BISHOP] | bitboards[BLACK_BISHOP] | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]
+                             : bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN];
+        sliders &= DIR_RAYS.diag[sq];
+        if (sliders) {
+            uint64_t diagAtt = getBAtt() & sliders;
+            while (diagAtt) {
+                int attSq = poplsb(diagAtt);
+                int attPiece = pieceBoard[attSq];
+                acc.addThreatChange(
+                    pieceType(attPiece), pieceColor(attPiece), pType, pCol, attSq, sq, sign);
+            }
+        }
+    }
+
+    // Straight sliders attacking sq. No rook->queen threat either.
+    {
+        uint64_t sliders = (pType != QUEEN)
+                             ? bitboards[WHITE_ROOK] | bitboards[BLACK_ROOK] | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]
+                             : bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN];
+        sliders &= DIR_RAYS.straight[sq];
+        if (sliders) {
+            uint64_t straightAtt = getRAtt() & sliders;
+            while (straightAtt) {
+                int attSq = poplsb(straightAtt);
+                int attPiece = pieceBoard[attSq];
+                acc.addThreatChange(
+                    pieceType(attPiece), pieceColor(attPiece), pType, pCol, attSq, sq, sign);
+            }
+        }
+    }
+}
+
+void Board::updateDiscoveredThreats(int sq, int sign) {
+    auto&          acc = nnueData.accumulator[nnueData.size];
+    const uint64_t occ = (occupied[WHITE] | occupied[BLACK]) & ~(1ULL << sq);
+
+    // Occupying or vacating sq blocks or opens the line between the nearest
+    // piece on each side of it. Only a slider of the matching type, or a queen,
+    // can hold that line.
+    auto line = [&](uint64_t attacks, const uint64_t* rayA, const uint64_t* rayB, int slider) {
+        const uint64_t a = attacks & rayA[sq] & occ;
+        const uint64_t b = attacks & rayB[sq] & occ;
+        if (!a || !b)
+            return;
+
+        const int sqA = bitScanForward(a), sqB = bitScanForward(b);
+        const int pA = pieceBoard[sqA], pB = pieceBoard[sqB];
+        if (pA == EMPTY || pB == EMPTY)
+            return;
+
+        const int tA = pieceType(pA), cA = pieceColor(pA);
+        const int tB = pieceType(pB), cB = pieceColor(pB);
+        if (tA == slider || tA == QUEEN)
+            acc.addThreatChange(tA, cA, tB, cB, sqA, sqB, sign);
+        if (tB == slider || tB == QUEEN)
+            acc.addThreatChange(tB, cB, tA, cA, sqB, sqA, sign);
+    };
+
+    const uint64_t diag = bishopAttacks(occ, sq);
+    line(diag, DIR_RAYS.north_east, DIR_RAYS.south_west, BISHOP);
+    line(diag, DIR_RAYS.north_west, DIR_RAYS.south_east, BISHOP);
+
+    const uint64_t straight = rookAttacks(occ, sq);
+    line(straight, DIR_RAYS.north, DIR_RAYS.south, ROOK);
+    line(straight, DIR_RAYS.east, DIR_RAYS.west, ROOK);
+}
+
+void Board::addPiece(int piece, int sq, bool updateNNUE) {
+    if (updateNNUE) {
+        updateDiscoveredThreats(sq, -1);
+    }
+
     pieceBoard[sq] = piece;
     setBit(bitboards[piece], sq);
     setBit(occupied[pieceColor(piece)], sq);
 
-    nnueData.accumulator[nnueData.size].addChange(piece, sq, 1);
+    if (updateNNUE) {
+        updateThreatsForPiece(piece, sq, 1);
+        nnueData.accumulator[nnueData.size].addChange(piece, sq, 1);
+    }
 
     key ^= Zobrist::Instance()->PieceKeys[piece][sq];
 
@@ -153,12 +320,19 @@ void Board::addPiece(int piece, int sq) {
     }
 }
 
-void Board::removePiece(int piece, int sq) {
+void Board::removePiece(int piece, int sq, bool updateNNUE) {
+    if (updateNNUE) {
+        updateThreatsForPiece(piece, sq, -1);
+    }
+
     pieceBoard[sq] = EMPTY;
     clearBit(bitboards[piece], sq);
     clearBit(occupied[pieceColor(piece)], sq);
 
-    nnueData.accumulator[nnueData.size].addChange(piece, sq, -1);
+    if (updateNNUE) {
+        updateDiscoveredThreats(sq, 1);
+        nnueData.accumulator[nnueData.size].addChange(piece, sq, -1);
+    }
 
     key ^= Zobrist::Instance()->PieceKeys[piece][sq];
 
@@ -174,9 +348,9 @@ void Board::removePiece(int piece, int sq) {
     }
 }
 
-void Board::movePiece(int piece, int from, int to) {
-    addPiece(piece, to);
-    removePiece(piece, from);
+void Board::movePiece(int piece, int from, int to, bool updateNNUE) {
+    removePiece(piece, from, updateNNUE);
+    addPiece(piece, to, updateNNUE);
 }
 
 void Board::print() {
@@ -225,7 +399,7 @@ void Board::makeMove(uint16_t move, bool updateNNUE) {
     if (updateNNUE)
     {
         nnueData.size++;
-        nnueData.accumulator[nnueData.size].invalidate();
+        nnueData.accumulator[nnueData.size].clear();
     }
 
     //remove enPassant and Castling keys
@@ -285,6 +459,9 @@ void Board::makeMove(uint16_t move, bool updateNNUE) {
     case ROOK_PROMOTION_CAPTURE :
     case QUEEN_PROMOTION_CAPTURE :
         removePiece(capturedPiece, to);
+        removePiece(piece, from);
+        addPiece(pieceIndex(sideToMove, KNIGHT + (movetype & 3)), to);
+        break;
     case KNIGHT_PROMOTION :
     case BISHOP_PROMOTION :
     case ROOK_PROMOTION :
@@ -314,6 +491,8 @@ void Board::makeMove(uint16_t move, bool updateNNUE) {
         acc.kingSq[WHITE]  = static_cast<uint8_t>(bitScanForward(bitboards[WHITE_KING]));
         acc.kingSq[BLACK]  = static_cast<uint8_t>(bitScanForward(bitboards[BLACK_KING]));
         acc.stateValid     = true;
+
+        NNUE::Instance()->refreshOnBucketChange(*this);
     }
 }
 
@@ -334,49 +513,46 @@ void Board::unmakeMove(uint16_t move, bool updateNNUE) {
     int capturedPiece = info.capturedPiece;
     int piece         = this->pieceBoard[to];
 
-
     switch (movetype)
     {
     case QUIET :
     case DOUBLE_PAWN_PUSH :
-        movePiece(piece, to, from);
+        movePiece(piece, to, from, false);
         break;
     case CAPTURE :
-        movePiece(piece, to, from);
-        addPiece(capturedPiece, to);
+        movePiece(piece, to, from, false);
+        addPiece(capturedPiece, to, false);
         break;
     case KING_CASTLE :
-        removePiece(piece, to);
-        removePiece(pieceIndex(sideToMove, ROOK), to - 1);
-        addPiece(piece, from);
-        addPiece(pieceIndex(sideToMove, ROOK), castlingRooks[2 * sideToMove]);
-
+        removePiece(piece, to, false);
+        removePiece(pieceIndex(sideToMove, ROOK), to - 1, false);
+        addPiece(piece, from, false);
+        addPiece(pieceIndex(sideToMove, ROOK), castlingRooks[2 * sideToMove], false);
         break;
     case QUEEN_CASTLE :
-        removePiece(piece, to);
-        removePiece(pieceIndex(sideToMove, ROOK), to + 1);
-        addPiece(piece, from);
-        addPiece(pieceIndex(sideToMove, ROOK), castlingRooks[2 * sideToMove + 1]);
-
+        removePiece(piece, to, false);
+        removePiece(pieceIndex(sideToMove, ROOK), to + 1, false);
+        addPiece(piece, from, false);
+        addPiece(pieceIndex(sideToMove, ROOK), castlingRooks[2 * sideToMove + 1], false);
         break;
     case EN_PASSANT :
-        movePiece(piece, to, from);
-        addPiece(capturedPiece, squareIndex(rankIndex(from), fileIndex(to)));
+        movePiece(piece, to, from, false);
+        addPiece(capturedPiece, squareIndex(rankIndex(from), fileIndex(to)), false);
         break;
     case KNIGHT_PROMOTION_CAPTURE :
     case BISHOP_PROMOTION_CAPTURE :
     case ROOK_PROMOTION_CAPTURE :
     case QUEEN_PROMOTION_CAPTURE :
-        removePiece(piece, to);
-        addPiece(pieceIndex(sideToMove, PAWN), from);
-        addPiece(capturedPiece, to);
+        removePiece(piece, to, false);
+        addPiece(pieceIndex(sideToMove, PAWN), from, false);
+        addPiece(capturedPiece, to, false);
         break;
     case KNIGHT_PROMOTION :
     case BISHOP_PROMOTION :
     case ROOK_PROMOTION :
     case QUEEN_PROMOTION :
-        removePiece(piece, to);
-        addPiece(pieceIndex(sideToMove, PAWN), from);
+        removePiece(piece, to, false);
+        addPiece(pieceIndex(sideToMove, PAWN), from, false);
         break;
     default :
         break;
@@ -384,7 +560,7 @@ void Board::unmakeMove(uint16_t move, bool updateNNUE) {
     key = info.key;
     if (updateNNUE)
     {
-        nnueData.accumulator[nnueData.size].invalidate();
+        nnueData.accumulator[nnueData.size].clear();
         nnueData.size = std::max(0, nnueData.size - 1);
     }
 }
@@ -466,7 +642,6 @@ bool Board::hasNonPawnPieces() {
         && (bitboards[BLACK_KNIGHT] || bitboards[BLACK_BISHOP] || bitboards[BLACK_ROOK] || bitboards[BLACK_QUEEN]);
 }
 
-
 bool Board::isMaterialDraw() {
     if (bitboards[WHITE_PAWN] || bitboards[BLACK_PAWN] || bitboards[WHITE_ROOK] || bitboards[BLACK_ROOK] || bitboards[WHITE_QUEEN] || bitboards[BLACK_QUEEN])
         return false;
@@ -528,5 +703,4 @@ bool Board::inCheck(uint64_t threat) {
         return true;
     return false;
 }
-
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -133,38 +133,19 @@ Board::Board(const std::string& fen) {
 }
 
 void Board::updateThreatsForPiece(int piece, int sq, int sign) {
-    if (piece == EMPTY) return;
+    if (piece == EMPTY || pieceType(piece) == KING) return;
     auto& acc = nnueData.accumulator[nnueData.size];
     int pType = pieceType(piece);
     int pCol  = pieceColor(piece);
     uint64_t occ = occupied[WHITE] | occupied[BLACK];
 
-    uint64_t bAtt = 0;
-    uint64_t rAtt = 0;
-    bool bAttComputed = false;
-    bool rAttComputed = false;
+    uint64_t bAtt = 0, rAtt = 0;
+    bool     haveB = false, haveR = false;
 
-    auto getBAtt = [&]() -> uint64_t {
-        if (!bAttComputed) {
-            bAtt = bishopAttacks(occ, sq);
-            bAttComputed = true;
-        }
-        return bAtt;
-    };
+    auto getBAtt = [&] { if (!haveB) { bAtt = bishopAttacks(occ, sq); haveB = true; } return bAtt; };
+    auto getRAtt = [&] { if (!haveR) { rAtt = rookAttacks(occ, sq); haveR = true; } return rAtt; };
 
-    auto getRAtt = [&]() -> uint64_t {
-        if (!rAttComputed) {
-            rAtt = rookAttacks(occ, sq);
-            rAttComputed = true;
-        }
-        return rAtt;
-    };
-    
-    if (pType == KING) return; // King is never a threat target
-
-    // 1. Outgoing threats: pieces attacked by this piece. Only the target mask
-    // differs per piece type; the feature space has no threat onto a king, and
-    // none from a bishop or rook onto a queen.
+    // Outgoing threats; the masks are the complement form of THREAT_VICTIMS.
     const uint64_t kings = bitboards[WHITE_KING] | bitboards[BLACK_KING];
     uint64_t       attacked = 0;
     switch (pType)
@@ -196,7 +177,6 @@ void Board::updateThreatsForPiece(int piece, int sq, int sign) {
         acc.addThreatChange(pType, pCol, pieceType(victim), pieceColor(victim), sq, dest, sign);
     }
 
-    // Pawns attacking sq (only if target is Knight or Rook)
     if (pType == KNIGHT || pType == ROOK) {
         uint64_t whitePawnAtt = PawnAttacks[BLACK][sq] & bitboards[WHITE_PAWN];
         while (whitePawnAtt) {
@@ -212,7 +192,6 @@ void Board::updateThreatsForPiece(int piece, int sq, int sign) {
         }
     }
 
-    // Knights attacking sq
     uint64_t knightAtt = KnightAttacks[sq] & (bitboards[WHITE_KNIGHT] | bitboards[BLACK_KNIGHT]);
     while (knightAtt) {
         int attSq = poplsb(knightAtt);
@@ -221,8 +200,7 @@ void Board::updateThreatsForPiece(int piece, int sq, int sign) {
             KNIGHT, attCol, pType, pCol, attSq, sq, sign);
     }
 
-    // Diagonal sliders attacking sq. No bishop->queen threat exists, so a queen
-    // victim narrows the attackers to queens.
+    // A queen victim narrows the attackers to queens; nothing else reaches one.
     {
         uint64_t sliders = (pType != QUEEN)
                              ? bitboards[WHITE_BISHOP] | bitboards[BLACK_BISHOP] | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]
@@ -239,7 +217,6 @@ void Board::updateThreatsForPiece(int piece, int sq, int sign) {
         }
     }
 
-    // Straight sliders attacking sq. No rook->queen threat either.
     {
         uint64_t sliders = (pType != QUEEN)
                              ? bitboards[WHITE_ROOK] | bitboards[BLACK_ROOK] | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]
@@ -272,9 +249,6 @@ void Board::updateDiscoveredThreats(int sq, int sign) {
 
         const int sqA = bitScanForward(a), sqB = bitScanForward(b);
         const int pA = pieceBoard[sqA], pB = pieceBoard[sqB];
-        if (pA == EMPTY || pB == EMPTY)
-            return;
-
         const int tA = pieceType(pA), cA = pieceColor(pA);
         const int tB = pieceType(pB), cB = pieceColor(pB);
         if (tA == slider || tA == QUEEN)
@@ -283,13 +257,21 @@ void Board::updateDiscoveredThreats(int sq, int sign) {
             acc.addThreatChange(tB, cB, tA, cA, sqB, sqA, sign);
     };
 
-    const uint64_t diag = bishopAttacks(occ, sq);
-    line(diag, DIR_RAYS.north_east, DIR_RAYS.south_west, BISHOP);
-    line(diag, DIR_RAYS.north_west, DIR_RAYS.south_east, BISHOP);
+    const uint64_t diagSliders = (bitboards[WHITE_BISHOP] | bitboards[BLACK_BISHOP] | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]) & DIR_RAYS.diag[sq];
+    if (diagSliders)
+    {
+        const uint64_t diag = bishopAttacks(occ, sq);
+        line(diag, DIR_RAYS.north_east, DIR_RAYS.south_west, BISHOP);
+        line(diag, DIR_RAYS.north_west, DIR_RAYS.south_east, BISHOP);
+    }
 
-    const uint64_t straight = rookAttacks(occ, sq);
-    line(straight, DIR_RAYS.north, DIR_RAYS.south, ROOK);
-    line(straight, DIR_RAYS.east, DIR_RAYS.west, ROOK);
+    const uint64_t straightSliders = (bitboards[WHITE_ROOK] | bitboards[BLACK_ROOK] | bitboards[WHITE_QUEEN] | bitboards[BLACK_QUEEN]) & DIR_RAYS.straight[sq];
+    if (straightSliders)
+    {
+        const uint64_t straight = rookAttacks(occ, sq);
+        line(straight, DIR_RAYS.north, DIR_RAYS.south, ROOK);
+        line(straight, DIR_RAYS.east, DIR_RAYS.west, ROOK);
+    }
 }
 
 void Board::addPiece(int piece, int sq, bool updateNNUE) {
@@ -485,14 +467,25 @@ void Board::makeMove(uint16_t move, bool updateNNUE) {
     // updated incrementally at all.
     if (updateNNUE)
     {
-        auto& acc          = nnueData.accumulator[nnueData.size];
-        acc.pawns[WHITE]   = bitboards[WHITE_PAWN];
-        acc.pawns[BLACK]   = bitboards[BLACK_PAWN];
-        acc.kingSq[WHITE]  = static_cast<uint8_t>(bitScanForward(bitboards[WHITE_KING]));
-        acc.kingSq[BLACK]  = static_cast<uint8_t>(bitScanForward(bitboards[BLACK_KING]));
-        acc.stateValid     = true;
+        auto&       acc  = nnueData.accumulator[nnueData.size];
+        const auto& prev = nnueData.accumulator[nnueData.size - 1];
 
-        NNUE::Instance()->refreshOnBucketChange(*this);
+        acc.pawns[WHITE] = bitboards[WHITE_PAWN];
+        acc.pawns[BLACK] = bitboards[BLACK_PAWN];
+        acc.stateValid   = true;
+
+        if (pieceType(piece) == KING || !prev.stateValid)
+        {
+            acc.kingSq[WHITE] = static_cast<uint8_t>(bitScanForward(bitboards[WHITE_KING]));
+            acc.kingSq[BLACK] = static_cast<uint8_t>(bitScanForward(bitboards[BLACK_KING]));
+
+            NNUE::Instance()->refreshOnBucketChange(*this, static_cast<Color>(pieceColor(piece)));
+        }
+        else
+        {
+            acc.kingSq[WHITE] = prev.kingSq[WHITE];
+            acc.kingSq[BLACK] = prev.kingSq[BLACK];
+        }
     }
 }
 

--- a/src/board.h
+++ b/src/board.h
@@ -12,11 +12,11 @@ class Board {
 
     std::string getFen();
 
-    void addPiece(int piece, int sq);
+    void addPiece(int piece, int sq, bool updateNNUE = true);
 
-    void removePiece(int piece, int sq);
+    void removePiece(int piece, int sq, bool updateNNUE = true);
 
-    void movePiece(int piece, int from, int to);
+    void movePiece(int piece, int from, int to, bool updateNNUE = true);
 
     int eval();
 
@@ -39,6 +39,10 @@ class Board {
     bool inCheck();
 
     bool inCheck(uint64_t threat);
+
+    void updateThreatsForPiece(int piece, int sq, int sign);
+
+    void updateDiscoveredThreats(int sq, int sign);
 
     uint64_t threat();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,14 +8,11 @@ int main(int argc, char** argv) {
         runDatagen(argc, argv);
         return 0;
     }
-    if (argc > 1)
-        std::cout << std::string(argv[1]);
     if (argc > 1 && std::string(argv[1]) == "bench")
     {
         bench(argc, argv);
         return 0;
     }
-
     auto uci = new Uci();
     uci->UciLoop();
     return 0;

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -1,13 +1,15 @@
 #include "nnue.h"
+
+#include "attack.h"
 #include "simd.h"
 #include "util.h"
 #include "incbin/incbin.h"
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <utility>
 #include <vector>
 
 #ifndef NET
@@ -18,20 +20,8 @@ INCBIN(EmbeddedNet, NET);
 
 namespace {
 
-constexpr int EVAL_SCALE = 400;
-
-// The pairwise stage lands at QA * QA >> INPUT_SHIFT = 126.008, not QA.
-constexpr float PAIRWISE_QUANT   = static_cast<float>(NNUE::QA) * NNUE::QA / (1 << NNUE::INPUT_SHIFT);
-constexpr int   PAIRWISE_MAX     = (NNUE::QA * NNUE::QA) >> NNUE::INPUT_SHIFT;
-static_assert(PAIRWISE_MAX == 126, "the pairwise activations must fit in int8");
-
-static_assert(2 * PAIRWISE_MAX * 127 <= 32767, "maddubs would saturate");
-
-// int16 accumulator: the bias plus every one of the 32 psq and 96 pawn-pair rows
-// at the int8 cap, all in one cell.
-static_assert(NNUE::QA + (32 + 96) * 127 <= 32767, "the accumulator would overflow");
-
 // clang-format off
+// MUST match devre_threat.rs's expand_mirrored(KING_BUCKET_HALF).
 constexpr uint8_t KING_BUCKET_LAYOUT[64] = {
      0,  1,  2,  3,  3,  2,  1,  0,
      4,  5,  6,  7,  7,  6,  5,  4,
@@ -61,84 +51,204 @@ constexpr std::array<uint64_t, 8> ADJACENT_FILES = [] {
     return table;
 }();
 
+// --- Tactical Threat Tables (constexpr) -------------------------------------
+
+struct ThreatTables {
+    int8_t   pawn_map[12];
+    struct NonPkData {
+        uint64_t attacks[64];
+        uint16_t indices[64];
+        int8_t   targets[12];
+        uint16_t count;
+    } non_pk[4]; // 0=Knight, 1=Bishop, 2=Rook, 3=Queen
+    uint32_t offsets[5];
+    int16_t  non_pk_index[4][64][64];
+    int16_t  pawn_index[64][64];
+
+    constexpr ThreatTables() : pawn_map{}, non_pk{}, offsets{}, non_pk_index{}, pawn_index{} {
+        for (int i = 0; i < 12; i++) {
+            pawn_map[i] = -1;
+            for (int p = 0; p < 4; p++) non_pk[p].targets[i] = -1;
+        }
+
+        // Relative targets: 0..5 Friendly, 6..11 Enemy
+        // Pawn targets: Knight (1), Rook (3) -> Friendly 0, 1; Enemy 2, 3
+        pawn_map[1] = 0;
+        pawn_map[3] = 1;
+        pawn_map[7] = 2;
+        pawn_map[9] = 3;
+
+        // Knight targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3), QUEEN(4) (N=5)
+        non_pk[0].targets[0] = 0; non_pk[0].targets[6]  = 5;
+        non_pk[0].targets[1] = 1; non_pk[0].targets[7]  = 6;
+        non_pk[0].targets[2] = 2; non_pk[0].targets[8]  = 7;
+        non_pk[0].targets[3] = 3; non_pk[0].targets[9]  = 8;
+        non_pk[0].targets[4] = 4; non_pk[0].targets[10] = 9;
+
+        // Bishop targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3) (N=4)
+        non_pk[1].targets[0] = 0; non_pk[1].targets[6]  = 4;
+        non_pk[1].targets[1] = 1; non_pk[1].targets[7]  = 5;
+        non_pk[1].targets[2] = 2; non_pk[1].targets[8]  = 6;
+        non_pk[1].targets[3] = 3; non_pk[1].targets[9]  = 7;
+
+        // Rook targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3) (N=4)
+        non_pk[2].targets[0] = 0; non_pk[2].targets[6]  = 4;
+        non_pk[2].targets[1] = 1; non_pk[2].targets[7]  = 5;
+        non_pk[2].targets[2] = 2; non_pk[2].targets[8]  = 6;
+        non_pk[2].targets[3] = 3; non_pk[2].targets[9]  = 7;
+
+        // Queen targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3), QUEEN(4) (N=5)
+        non_pk[3].targets[0] = 0; non_pk[3].targets[6]  = 5;
+        non_pk[3].targets[1] = 1; non_pk[3].targets[7]  = 6;
+        non_pk[3].targets[2] = 2; non_pk[3].targets[8]  = 7;
+        non_pk[3].targets[3] = 3; non_pk[3].targets[9]  = 8;
+        non_pk[3].targets[4] = 4; non_pk[3].targets[10] = 9;
+
+        for (int sq = 0; sq < 64; sq++) {
+            non_pk[0].attacks[sq] = KnightAttacks[sq];
+            non_pk[0].indices[sq] = non_pk[0].count;
+            non_pk[0].count += popcount64(non_pk[0].attacks[sq]);
+
+            non_pk[1].attacks[sq] = DIR_RAYS.diag[sq];
+            non_pk[1].indices[sq] = non_pk[1].count;
+            non_pk[1].count += popcount64(non_pk[1].attacks[sq]);
+
+            non_pk[2].attacks[sq] = DIR_RAYS.straight[sq];
+            non_pk[2].indices[sq] = non_pk[2].count;
+            non_pk[2].count += popcount64(non_pk[2].attacks[sq]);
+
+            non_pk[3].attacks[sq] = DIR_RAYS.diag[sq] | DIR_RAYS.straight[sq];
+            non_pk[3].indices[sq] = non_pk[3].count;
+            non_pk[3].count += popcount64(non_pk[3].attacks[sq]);
+        }
+
+        offsets[0] = 4 * 84;
+        offsets[1] = offsets[0] + 10 * non_pk[0].count;
+        offsets[2] = offsets[1] + 8 * non_pk[1].count;
+        offsets[3] = offsets[2] + 8 * non_pk[2].count;
+        offsets[4] = offsets[3] + 10 * non_pk[3].count;
+
+        for (int p = 0; p < 4; p++) {
+            for (int src = 0; src < 64; src++) {
+                for (int dest = 0; dest < 64; dest++) {
+                    uint64_t mask = (1ULL << dest) - 1ULL;
+                    int count = popcount64(non_pk[p].attacks[src] & mask);
+                    non_pk_index[p][src][dest] = non_pk[p].indices[src] + count;
+                }
+            }
+        }
+
+        for (int src = 0; src < 64; src++) {
+            for (int dest = 0; dest < 64; dest++) {
+                int diff = (dest > src) ? (dest - src) : (src - dest);
+                int expected = (dest > src) ? 7 : 9;
+                int id = (diff == expected) ? 0 : 1;
+                int attack = 2 * (src % 8) + id - 1;
+                int rank = src / 8;
+                if (rank < 1 || rank > 6 || attack < 0 || attack >= 14) {
+                    pawn_index[src][dest] = -1;
+                } else {
+                    pawn_index[src][dest] = (rank - 1) * 14 + attack;
+                }
+            }
+        }
+    }
+};
+constexpr ThreatTables THREAT_TABLES{};
+
+// A wrong attack mask shifts every offset after it and silently repoints the
+// threat features, so pin the totals.
+static_assert(THREAT_TABLES.non_pk[0].count == 336, "knight attack table is wrong");
+static_assert(THREAT_TABLES.non_pk[1].count == 560, "bishop attack table is wrong");
+static_assert(THREAT_TABLES.non_pk[2].count == 896, "rook attack table is wrong");
+static_assert(THREAT_TABLES.non_pk[3].count == 1456, "queen attack table is wrong");
+static_assert(2 * THREAT_TABLES.offsets[4] == NNUE::NUM_THREATS,
+              "threat index space disagrees with the trainer");
+
+constexpr int mapThreatSingle(const ThreatTables& tbl, int piece, int src, int dest, int target) {
+    if (target < 0 || target >= 12) return -1;
+    if (piece == PAWN) {
+        int targetId = tbl.pawn_map[target];
+        if (targetId < 0) return -1;
+        int baseIdx = tbl.pawn_index[src][dest];
+        if (baseIdx < 0) return -1;
+        return targetId * 84 + baseIdx;
+    } else {
+        int pieceIdx = piece - 1; // Knight=1 -> 0, Bishop=2 -> 1, Rook=3 -> 2, Queen=4 -> 3
+        if (pieceIdx < 0 || pieceIdx >= 4) return -1;
+        const auto& pk = tbl.non_pk[pieceIdx];
+        int piece_target = pk.targets[target];
+        if (piece_target < 0) return -1;
+        if (dest > src && ((target % 6) == piece)) return -1;
+        int index = tbl.non_pk_index[pieceIdx][src][dest];
+        return tbl.offsets[pieceIdx] + piece_target * pk.count + index;
+    }
+}
+
+struct FlatThreatTable {
+    int16_t map[5][64][64][12];
+    constexpr FlatThreatTable() : map{} {
+        for (int p = 0; p < 5; p++) {
+            for (int s = 0; s < 64; s++) {
+                for (int d = 0; d < 64; d++) {
+                    for (int t = 0; t < 12; t++) {
+                        map[p][s][d][t] = static_cast<int16_t>(mapThreatSingle(THREAT_TABLES, p, s, d, t));
+                    }
+                }
+            }
+        }
+    }
+};
+constexpr FlatThreatTable FLAT_THREAT_TABLE{};
+
+// 480 KB, against 40 KB for computing the index on the fly; measured 5.7% faster.
+inline int mapThreatFast(int piece, int src, int dest, int target) {
+    if (static_cast<unsigned>(piece) >= 5 || static_cast<unsigned>(target) >= 12) return -1;
+    return FLAT_THREAT_TABLE.map[piece][src][dest][target];
+}
+
 // --- Accumulator arithmetic -------------------------------------------------
 
-constexpr uint32_t numBlocks = NNUE_FT_OUT / SIMD::vecSize;
-static_assert(NNUE_FT_OUT % SIMD::vecSize == 0);
+// The psq half has no bias of its own; the FT bias lives in the tac half.
+alignas(64) constexpr int16_t ZERO_ACC[NNUE_FT_OUT] = {};
 
-/// `out = base + sum(addRows) - sum(subRows)` in one pass.
-///
-/// `out` may alias `base` -- the refresh cache updates in place -- so nothing is
-/// `restrict`. Each chunk loads before it stores, so aliasing is safe.
+// One line is enough; the loop walks the row front to back. Worth ~5% of
+// accumulator time, more lines cost more in load slots than they save.
+inline void prefetchRow(const int8_t* row) { __builtin_prefetch(row, 0, 3); }
+
+// Measured flat from 4 to 8, worse either side.
+constexpr uint32_t ACC_BLOCK = 4;
+static_assert(NNUE_FT_OUT % (ACC_BLOCK * SIMD::vecSize) == 0, "column blocks must tile the accumulator");
+
+/// out = base + sum(addRows) - sum(subRows). Rows are int8, widened on load.
 inline __attribute__((always_inline)) void
 accumulateRows(int16_t* out, const int16_t* base, const int8_t* const* addRows, int nAdd,
                const int8_t* const* subRows, int nSub) {
-    constexpr uint32_t chunkBlocks = (numBlocks < 8) ? numBlocks : 8;
-
-    if (nAdd == 1 && nSub == 1)
-    {
-        const int8_t* add = addRows[0];
-        const int8_t* sub = subRows[0];
-        for (uint32_t chunk = 0; chunk < numBlocks; chunk += chunkBlocks)
-        {
-            const uint32_t offset = chunk * SIMD::vecSize;
-            for (uint32_t b = 0; b < chunkBlocks; b++)
-            {
-                const uint32_t idx = offset + b * SIMD::vecSize;
-                SIMD::vecType acc = SIMD::vecLoad(base + idx);
-                acc = SIMD::vecAddEpi16(acc, SIMD::vecLoadI8ToI16(add + idx));
-                acc = SIMD::vecSubEpi16(acc, SIMD::vecLoadI8ToI16(sub + idx));
-                SIMD::vecStore(out + idx, acc);
-            }
-        }
+    if (nAdd == 0 && nSub == 0) {
+        std::memcpy(out, base, sizeof(int16_t) * NNUE_FT_OUT);
         return;
     }
 
-    if (nAdd == 1 && nSub == 2)
-    {
-        const int8_t* add  = addRows[0];
-        const int8_t* sub0 = subRows[0];
-        const int8_t* sub1 = subRows[1];
-        for (uint32_t chunk = 0; chunk < numBlocks; chunk += chunkBlocks)
-        {
-            const uint32_t offset = chunk * SIMD::vecSize;
-            for (uint32_t b = 0; b < chunkBlocks; b++)
-            {
-                const uint32_t idx = offset + b * SIMD::vecSize;
-                SIMD::vecType acc = SIMD::vecLoad(base + idx);
-                acc = SIMD::vecAddEpi16(acc, SIMD::vecLoadI8ToI16(add + idx));
-                acc = SIMD::vecSubEpi16(acc, SIMD::vecLoadI8ToI16(sub0 + idx));
-                acc = SIMD::vecSubEpi16(acc, SIMD::vecLoadI8ToI16(sub1 + idx));
-                SIMD::vecStore(out + idx, acc);
-            }
-        }
-        return;
-    }
+    constexpr uint32_t step = ACC_BLOCK * SIMD::vecSize;
+    for (uint32_t i = 0; i < NNUE_FT_OUT; i += step) {
+        SIMD::vecType acc[ACC_BLOCK];
+        for (uint32_t v = 0; v < ACC_BLOCK; v++)
+            acc[v] = SIMD::vecLoad(base + i + v * SIMD::vecSize);
 
-    for (uint32_t chunk = 0; chunk < numBlocks; chunk += chunkBlocks)
-    {
-        const uint32_t offset = chunk * SIMD::vecSize;
-
-        SIMD::vecType acc[chunkBlocks];
-        for (uint32_t b = 0; b < chunkBlocks; b++)
-            acc[b] = SIMD::vecLoad(base + offset + b * SIMD::vecSize);
-
-        for (int a = 0; a < nAdd; a++)
-        {
-            const int8_t* row = addRows[a] + offset;
-            for (uint32_t b = 0; b < chunkBlocks; b++)
-                acc[b] = SIMD::vecAddEpi16(acc[b], SIMD::vecLoadI8ToI16(row + b * SIMD::vecSize));
+        for (int a = 0; a < nAdd; a++) {
+            const int8_t* row = addRows[a];
+            for (uint32_t v = 0; v < ACC_BLOCK; v++)
+                acc[v] = SIMD::vecAddEpi16(acc[v], SIMD::vecLoadI8ToI16(row + i + v * SIMD::vecSize));
         }
 
-        for (int s = 0; s < nSub; s++)
-        {
-            const int8_t* row = subRows[s] + offset;
-            for (uint32_t b = 0; b < chunkBlocks; b++)
-                acc[b] = SIMD::vecSubEpi16(acc[b], SIMD::vecLoadI8ToI16(row + b * SIMD::vecSize));
+        for (int s = 0; s < nSub; s++) {
+            const int8_t* row = subRows[s];
+            for (uint32_t v = 0; v < ACC_BLOCK; v++)
+                acc[v] = SIMD::vecSubEpi16(acc[v], SIMD::vecLoadI8ToI16(row + i + v * SIMD::vecSize));
         }
 
-        for (uint32_t b = 0; b < chunkBlocks; b++)
-            SIMD::vecStore(out + offset + b * SIMD::vecSize, acc[b]);
+        for (uint32_t v = 0; v < ACC_BLOCK; v++)
+            SIMD::vecStore(out + i + v * SIMD::vecSize, acc[v]);
     }
 }
 
@@ -151,10 +261,7 @@ inline float screlu(float x) {
 
 // --- File format ------------------------------------------------------------
 
-// 48-byte header (magic, format version, nine architecture fields) then the
-// tensors back to back in NetworkData's declaration order. `VERSION` is already
-// the engine's own version macro, hence the prefix.
-constexpr char     MAGIC[8]    = {'D', 'V', 'N', 'N', 'U', 'E', '4', '\0'};
+constexpr char     MAGIC[8]    = {'D', 'V', 'N', 'N', 'U', 'E', '5', '\0'};
 constexpr uint32_t NET_VERSION = 1;
 constexpr size_t   HEADER_LEN  = 48;
 
@@ -163,7 +270,6 @@ uint32_t readU32(const uint8_t* p, size_t at) {
     std::memcpy(&v, p + at, sizeof(v));
     return v;
 }
-
 
 }  // namespace
 
@@ -199,85 +305,221 @@ int NNUE::pawnPairIndex(int idA, int idB) {
     return hi * (hi - 1) / 2 + lo;
 }
 
-int NNUE::outputBucket(const Board& board) {
-    const int pieces = popcount64(board.occupied[WHITE] | board.occupied[BLACK]);
-    return std::min((pieces - 2) / 4, OUTPUT_BUCKETS - 1);
-}
-
 // --- Full refresh -----------------------------------------------------------
 
-void NNUE::refresh(const Board& board, Color perspective, int16_t* accumulator) const {
-    const NetworkData&   net = *network;
+/// Rebuilds one or both halves; a nullptr skips that half, and skipping tac
+/// skips the threat generation, which is what a refresh actually costs.
+/// Rebuilds one or both halves; a nullptr skips that half, and skipping tac
+/// skips the threat generation, which is what a refresh actually costs.
+void NNUE::refresh(const Board& board, Color perspective, int16_t* psqOut, int16_t* tacOut) const {
     const PerspectiveKey key = perspectiveKey(bitScanForward(board.bitboards[pieceIndex(perspective, KING)]),
                                               perspective);
+    if (psqOut)
+        refreshPsq(board, perspective, key, psqOut);
+    if (tacOut)
+        refreshTac(board, perspective, key, tacOut);
+}
 
-    const int8_t* rows[32 + 96];
-    int           nRows = 0;
+/// One row per piece on the board.
+void NNUE::refreshPsq(const Board& board, Color perspective, PerspectiveKey key, int16_t* out) const {
+    const NetworkData& net = *network;
 
-    // Entry i of both buffers must be the same pawn: pawnPairIndex
-    // canonicalises each perspective independently.
+    const int8_t* rows[MAX_PSQ_ACTIVE];
+    int           n = 0;
+
+    uint64_t occupied = board.occupied[WHITE] | board.occupied[BLACK];
+    while (occupied && n < MAX_PSQ_ACTIVE)
+    {
+        const int sq = poplsb(occupied);
+        rows[n++]    = net.ftPsqWeights
+                  + static_cast<size_t>(psqFeature(board.pieceBoard[sq], sq, perspective, key)) * NNUE_FT_OUT;
+    }
+
+    accumulateRows(out, ZERO_ACC, rows, n, nullptr, 0);
+}
+
+/// Pawn-structure pairs plus every threat on the board -- the expensive half,
+/// which is why a bucket-only king move rebuilds psq without touching this.
+void NNUE::refreshTac(const Board& board, Color perspective, PerspectiveKey key, int16_t* out) const {
+    const NetworkData& net = *network;
+
+    const int8_t* tacRows[MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE];
+    int           nTac = 0;
+
     int pawnIds[16];
     int pawnFiles[16];
     int pawns = 0;
 
-    uint64_t occ = board.occupied[WHITE] | board.occupied[BLACK];
-    while (occ)
+    uint64_t pawnBB = board.bitboards[WHITE_PAWN] | board.bitboards[BLACK_PAWN];
+    while (pawnBB)
     {
-        const int sq    = poplsb(occ);
-        const int piece = board.pieceBoard[sq];
-
-        rows[nRows++] = net.ftWeights + static_cast<size_t>(psqFeature(piece, sq, perspective, key)) * NNUE_FT_OUT;
-
-        if (pieceType(piece) == PAWN)
-        {
-            pawnIds[pawns] = pawnId(sq, static_cast<Color>(pieceColor(piece)), perspective, key.flip);
-            pawnFiles[pawns] = sq & 7;
-            pawns++;
-        }
+        const int sq     = poplsb(pawnBB);
+        pawnIds[pawns]   = pawnId(sq, static_cast<Color>(pieceColor(board.pieceBoard[sq])), perspective, key.flip);
+        pawnFiles[pawns] = sq & 7;
+        pawns++;
     }
 
+    const uint64_t occ = board.occupied[WHITE] | board.occupied[BLACK];
+
+    // Pawn pairs
     for (int i = 0; i < pawns; i++)
         for (int j = i + 1; j < pawns; j++)
             if (std::abs(pawnFiles[i] - pawnFiles[j]) <= 1)
-                rows[nRows++] = net.ftWeights
-                              + static_cast<size_t>(PSQ_FEATURES + pawnPairIndex(pawnIds[i], pawnIds[j]))
-                                    * NNUE_FT_OUT;
+                if (nTac < MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE)
+                {
+                    tacRows[nTac++] = net.ftTacWeights
+                                    + static_cast<size_t>(pawnPairIndex(pawnIds[i], pawnIds[j]))
+                                          * NNUE_FT_OUT;
+                }
 
-    accumulateRows(accumulator, net.ftBiases, rows, nRows, nullptr, 0);
+    // Every (attacker, victim) pair on the board. Pairs the feature space does
+    // not cover come back as -1 and are dropped.
+    const Color us        = perspective;
+    const int   ourKingSq = bitScanForward(board.bitboards[pieceIndex(us, KING)]);
+    const int   hFlip     = (ourKingSq % 8 > 3) ? 7 : 0;
+    const int   flip      = (us == WHITE) ? hFlip : (56 ^ hFlip);
+
+    /// Records the threat from `sq` onto whatever occupies `dest`.
+    auto addThreat = [&](int piece, int sq, int dest, int offset) {
+        const int victim = board.pieceBoard[dest];
+        if (victim >= N_PIECES)  // EMPTY, i.e. pieceBoard disagreeing with occupied
+            return;
+        const int target = pieceType(victim) + (pieceColor(victim) == us ? 0 : 6);
+        const int index  = mapThreatFast(piece, sq ^ flip, dest ^ flip, target);
+        if (index >= 0 && nTac < MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE)
+        {
+            tacRows[nTac++] = net.ftTacWeights
+                            + static_cast<size_t>(PAWN_PAIRS + offset + index) * NNUE_FT_OUT;
+        }
+    };
+
+    /// Every occupied square `piece` on `sq` attacks.
+    auto addThreatsFrom = [&](int piece, int sq, uint64_t attacks, int offset) {
+        uint64_t targets = attacks & occ;
+        while (targets)
+            addThreat(piece, sq, poplsb(targets), offset);
+    };
+
+    for (const Color c : {us, ~us})
+    {
+        // The two colours occupy disjoint halves of the threat index space.
+        const int offset = (c == us) ? 0 : THREAT_TABLES.offsets[4];
+
+        // Pawns move as a block: shift the whole bitboard instead of walking it,
+        // then read each attacker's origin back off the destination square.
+        const uint64_t pawns = board.bitboards[pieceIndex(c, PAWN)];
+        const int      up    = (c == WHITE) ? 8 : -8;
+        uint64_t       east  = pawns & ~FILE_H_BB;
+        uint64_t       west  = pawns & ~FILE_A_BB;
+        east = ((c == WHITE) ? east << 9 : east >> 7) & occ;
+        west = ((c == WHITE) ? west << 7 : west >> 9) & occ;
+        while (east)
+        {
+            const int dest = poplsb(east);
+            addThreat(PAWN, dest - up - 1, dest, offset);
+        }
+        while (west)
+        {
+            const int dest = poplsb(west);
+            addThreat(PAWN, dest - up + 1, dest, offset);
+        }
+
+        uint64_t knights = board.bitboards[pieceIndex(c, KNIGHT)];
+        while (knights)
+        {
+            const int sq = poplsb(knights);
+            addThreatsFrom(KNIGHT, sq, KnightAttacks[sq], offset);
+        }
+
+        uint64_t bishops = board.bitboards[pieceIndex(c, BISHOP)];
+        while (bishops)
+        {
+            const int sq = poplsb(bishops);
+            addThreatsFrom(BISHOP, sq, bishopAttacks(occ, sq), offset);
+        }
+
+        uint64_t rooks = board.bitboards[pieceIndex(c, ROOK)];
+        while (rooks)
+        {
+            const int sq = poplsb(rooks);
+            addThreatsFrom(ROOK, sq, rookAttacks(occ, sq), offset);
+        }
+
+        uint64_t queens = board.bitboards[pieceIndex(c, QUEEN)];
+        while (queens)
+        {
+            const int sq = poplsb(queens);
+            addThreatsFrom(QUEEN, sq, bishopAttacks(occ, sq) | rookAttacks(occ, sq), offset);
+        }
+    }
+
+    accumulateRows(out, net.ftTacBiases, tacRows, nTac, nullptr, 0);
 }
 
 // --- Incremental update -----------------------------------------------------
 
-/// Apply ply `idx` on top of ply `idx - 1`: psq from the change list, pawn
-/// pairs from the pawn bitboards either side of the move.
-void NNUE::applyPly(Board& board, Color perspective, int idx, PerspectiveKey key) const {
+/// doPsq / doTac are independent: the psq chain breaks on any king-key change,
+/// the tac chain only when the mirror flips.
+void NNUE::applyPly(Board& board, Color perspective, int idx, PerspectiveKey key, bool doPsq, bool doTac) const {
     const NetworkData& net  = *network;
     auto&              cur  = board.nnueData.accumulator[idx];
     const auto&        prev = board.nnueData.accumulator[idx - 1];
 
-    // 4 psq + 2 moved pawns x 15 partners + 1 = 35.
-    const int8_t* addRows[48];
-    const int8_t* subRows[48];
-    int            nAdd = 0;
-    int            nSub = 0;
+    const int8_t* addRows[MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE];
+    const int8_t* subRows[MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE];
+    int           nAdd = 0;
+    int           nSub = 0;
 
-    auto row = [&](int feature) { return net.ftWeights + static_cast<size_t>(feature) * NNUE_FT_OUT; };
+    auto rowPsq = [&](int feature) {
+        const int8_t* row = net.ftPsqWeights + static_cast<size_t>(feature) * NNUE_FT_OUT;
+        prefetchRow(row);
+        return row;
+    };
 
-    for (int i = 0; i < cur.changeCount; i++)
+    if (doPsq)
     {
-        const auto& change  = cur.changes[i];
-        const int   feature = psqFeature(change.piece, change.sq, perspective, key);
-        if (change.sign > 0)
-            addRows[nAdd++] = row(feature);
-        else
-            subRows[nSub++] = row(feature);
+        for (int i = 0; i < cur.changeCount; i++)
+        {
+            const auto& change  = cur.changes[i];
+            const int   feature = psqFeature(change.piece, change.sq, perspective, key);
+            if (change.sign > 0)
+                addRows[nAdd++] = rowPsq(feature);
+            else
+                subRows[nSub++] = rowPsq(feature);
+        }
+
+        accumulateRows(cur.psq[perspective], prev.psq[perspective], addRows, nAdd, subRows, nSub);
+        cur.computedPsq[perspective] = true;
     }
+
+    if (!doTac)
+        return;
+
+    nAdd = 0;
+    nSub = 0;
 
     pawnPairDelta(prev.pawns, cur.pawns, perspective, key, addRows, nAdd, subRows, nSub);
 
+    for (int i = 0; i < cur.threatChangeCount; i++)
+    {
+        const DirtyThreat& t      = cur.threatChanges[i];
+        const int          offset = (t.pieceColor() == perspective) ? 0 : THREAT_TABLES.offsets[4];
+        const int          target = t.targetPiece() + (t.targetColor() == perspective ? 0 : 6);
+        const int          index  = mapThreatFast(t.piece(), t.sq ^ key.flip, t.dest ^ key.flip, target);
+        if (index < 0)
+            continue;
 
-    accumulateRows(cur.data[perspective], prev.data[perspective], addRows, nAdd, subRows, nSub);
-    cur.computed[perspective] = true;
+        const int8_t* row = net.ftTacWeights
+                          + static_cast<size_t>(PAWN_PAIRS + offset + index) * NNUE_FT_OUT;
+        prefetchRow(row);
+        if (t.sign() > 0)
+            addRows[nAdd++] = row;
+        else
+            subRows[nSub++] = row;
+    }
+
+    accumulateRows(cur.tac[perspective], prev.tac[perspective], addRows, nAdd, subRows, nSub);
+    cur.computedTac[perspective] = true;
 }
 
 void NNUE::pawnPairDelta(const uint64_t prevPawns[N_COLORS], const uint64_t curPawns[N_COLORS], Color perspective,
@@ -287,10 +529,12 @@ void NNUE::pawnPairDelta(const uint64_t prevPawns[N_COLORS], const uint64_t curP
         return;
 
     const NetworkData& net = *network;
-    auto row = [&](int feature) { return net.ftWeights + static_cast<size_t>(feature) * NNUE_FT_OUT; };
+    auto rowTac = [&](int feature) {
+        const int8_t* row = net.ftTacWeights + static_cast<size_t>(feature) * NNUE_FT_OUT;
+        prefetchRow(row);
+        return row;
+    };
 
-    // id in the low byte, file above it: recovering the file from the id would
-    // have to undo the mirror. A refresh can change all sixteen pawns.
     int removed[16], added[16];
     int nRemoved = 0, nAdded = 0;
 
@@ -326,19 +570,19 @@ void NNUE::pawnPairDelta(const uint64_t prevPawns[N_COLORS], const uint64_t curP
             while (partners)
             {
                 const int sq = poplsb(partners);
-                rows[n++]    = row(PSQ_FEATURES + pawnPairIndex(id, pawnId(sq, WHITE, perspective, key.flip)));
+                rows[n++]    = rowTac(pawnPairIndex(id, pawnId(sq, WHITE, perspective, key.flip)));
             }
 
             partners = keptBlack & ADJACENT_FILES[file];
             while (partners)
             {
                 const int sq = poplsb(partners);
-                rows[n++]    = row(PSQ_FEATURES + pawnPairIndex(id, pawnId(sq, BLACK, perspective, key.flip)));
+                rows[n++]    = rowTac(pawnPairIndex(id, pawnId(sq, BLACK, perspective, key.flip)));
             }
 
             for (int j = i + 1; j < count; j++)
                 if (std::abs(file - (moved[j] >> 8)) <= 1)
-                    rows[n++] = row(PSQ_FEATURES + pawnPairIndex(id, moved[j] & 0xFF));
+                    rows[n++] = rowTac(pawnPairIndex(id, moved[j] & 0xFF));
         }
     };
 
@@ -346,149 +590,170 @@ void NNUE::pawnPairDelta(const uint64_t prevPawns[N_COLORS], const uint64_t curP
     pairsWithKept(added, nAdded, addRows, nAdd);
 }
 
-/// Rebuild a perspective as a delta from the last position that used the same
-/// bucket and mirror, rather than from the bias. An empty entry degenerates to
-/// the bias rebuild, hence the full-rebuild row bound below.
-void NNUE::refreshFromCache(Board& board, Color perspective, PerspectiveKey key, int16_t* accumulator) const {
-    const NetworkData& net   = *network;
-    auto&              entry = board.nnueData.refreshCache[(perspective * KING_BUCKETS + key.bucket) * 2
-                                               + (key.flip & 7 ? 1 : 0)];
+void NNUE::refreshOnBucketChange(Board& board) const {
+    if (!loaded)
+        return;
 
-    if (!entry.initialised)
+    auto&     stack = board.nnueData.accumulator;
+    const int cur   = board.nnueData.size;
+    if (cur == 0 || !stack[cur - 1].stateValid)
+        return;
+
+    for (const Color p : {WHITE, BLACK})
     {
-        std::memcpy(entry.data, net.ftBiases, sizeof(net.ftBiases));
-        std::memset(entry.pieces, 0, sizeof(entry.pieces));
-        entry.initialised = true;
-    }
-
-    // 32 psq + at most 96 pawn pairs; no delta exceeds a full rebuild.
-    const int8_t* addRows[32 + 96];
-    const int8_t* subRows[32 + 96];
-    int            nAdd = 0;
-    int            nSub = 0;
-
-    auto row = [&](int feature) { return net.ftWeights + static_cast<size_t>(feature) * NNUE_FT_OUT; };
-
-    for (int piece = 0; piece < N_PIECES; piece++)
-    {
-        if (pieceType(piece) > KING)
+        const PerspectiveKey kNow  = perspectiveKey(stack[cur].kingSq[p], p);
+        const PerspectiveKey kPrev = perspectiveKey(stack[cur - 1].kingSq[p], p);
+        if (kNow == kPrev)
             continue;
-
-        uint64_t gone = entry.pieces[piece] & ~board.bitboards[piece];
-        while (gone)
-            subRows[nSub++] = row(psqFeature(piece, poplsb(gone), perspective, key));
-
-        uint64_t fresh = board.bitboards[piece] & ~entry.pieces[piece];
-        while (fresh)
-            addRows[nAdd++] = row(psqFeature(piece, poplsb(fresh), perspective, key));
+        if (kNow.flip != kPrev.flip)
+        {
+            // Mirror crossed: every feature index changes, both halves go.
+            refresh(board, p, stack[cur].psq[p], stack[cur].tac[p]);
+            stack[cur].computedTac[p] = true;
+        }
+        else
+        {
+            // Bucket only: tac indices depend on the mirror alone, so that half
+            // stays reachable. 90% of bucket changes land here.
+            refresh(board, p, stack[cur].psq[p], nullptr);
+        }
+        stack[cur].computedPsq[p] = true;
     }
-
-    const uint64_t cachedPawns[N_COLORS]  = {entry.pieces[WHITE_PAWN], entry.pieces[BLACK_PAWN]};
-    const uint64_t currentPawns[N_COLORS] = {board.bitboards[WHITE_PAWN], board.bitboards[BLACK_PAWN]};
-    pawnPairDelta(cachedPawns, currentPawns, perspective, key, addRows, nAdd, subRows, nSub);
-
-    if (nAdd != 0 || nSub != 0)
-        accumulateRows(entry.data, entry.data, addRows, nAdd, subRows, nSub);
-    std::memcpy(entry.pieces, board.bitboards, sizeof(entry.pieces));
-    std::memcpy(accumulator, entry.data, NNUE_FT_OUT * sizeof(int16_t));
 }
 
 void NNUE::updatePerspective(Board& board, Color perspective) const {
     auto&     stack = board.nnueData.accumulator;
     const int cur   = board.nnueData.size;
 
-    if (stack[cur].computed[perspective])
+    const bool needPsq = !stack[cur].computedPsq[perspective];
+    const bool needTac = !stack[cur].computedTac[perspective];
+    if (!needPsq && !needTac)
         return;
 
     const PerspectiveKey key = perspectiveKey(bitScanForward(board.bitboards[pieceIndex(perspective, KING)]),
                                               perspective);
 
-    // Nearest computed accumulator with the same key: a bucket or mirror change
-    // re-indexes every psq row and cannot be bridged with deltas.
-    int base = -1;
-    for (int i = cur - 1; i >= 0; i--)
-    {
-        if (!stack[i].stateValid || perspectiveKey(stack[i].kingSq[perspective], perspective) != key)
-            break;
-        if (stack[i].computed[perspective])
+    int basePsq = -1;
+    if (needPsq)
+        for (int i = cur - 1; i >= 0; i--)
         {
-            base = i;
-            break;
+            if (!stack[i].stateValid || perspectiveKey(stack[i].kingSq[perspective], perspective) != key)
+                break;
+            if (stack[i].computedPsq[perspective])
+            {
+                basePsq = i;
+                break;
+            }
         }
-    }
 
-    if (base < 0)
+    int baseTac = -1;
+    if (needTac)
+        for (int i = cur - 1; i >= 0; i--)
+        {
+            if (!stack[i].stateValid
+                || perspectiveKey(stack[i].kingSq[perspective], perspective).flip != key.flip)
+                break;
+            if (stack[i].computedTac[perspective])
+            {
+                baseTac = i;
+                break;
+            }
+        }
+
+    if (needPsq && basePsq < 0)
     {
-        refreshFromCache(board, perspective, key, stack[cur].data[perspective]);
-        stack[cur].computed[perspective] = true;
-        return;
+        refresh(board, perspective, stack[cur].psq[perspective], nullptr);
+        stack[cur].computedPsq[perspective] = true;
+    }
+    if (needTac && baseTac < 0)
+    {
+        refresh(board, perspective, nullptr, stack[cur].tac[perspective]);
+        stack[cur].computedTac[perspective] = true;
     }
 
-    for (int i = base + 1; i <= cur; i++)
-        applyPly(board, perspective, i, key);
+    // `cur + 1` means "this half needs no forward application".
+    const int fromPsq = (needPsq && basePsq >= 0) ? basePsq + 1 : cur + 1;
+    const int fromTac = (needTac && baseTac >= 0) ? baseTac + 1 : cur + 1;
+
+    for (int i = std::min(fromPsq, fromTac); i <= cur; i++)
+        applyPly(board, perspective, i, key, i >= fromPsq, i >= fromTac);
 }
 
 // --- Head -------------------------------------------------------------------
 
-/// L1 dot products are already done, in int32.
-int NNUE::finishHead(const int32_t* l1Dots, int bucket) const {
+int NNUE::finishHead(const int32_t* l1Dots) const {
     const NetworkData& net = *network;
 
+    // L1 feeds the head twice: through L2, and straight into the output layer.
     float l1Activations[2 * L1_SIZE];
     for (int i = 0; i < L1_SIZE; i++)
     {
-        const int   out   = bucket * L1_SIZE + i;
-        const float value = static_cast<float>(l1Dots[i]) * net.l1Norm[out] + net.l1Biases[out];
+        const float value          = static_cast<float>(l1Dots[i]) * net.l1Norm[i] + net.l1Biases[i];
         l1Activations[i]           = crelu(value);
         l1Activations[L1_SIZE + i] = screlu(value);
     }
 
-    // Across outputs, not within one: the weights are input-major, so each
-    // input is one contiguous FMA over all 32 outputs and nothing reduces.
-    alignas(64) float head[HEAD_SIZE];
-    std::memcpy(head, net.l2Biases + bucket * L2_SIZE, L2_SIZE * sizeof(float));
+    constexpr int F        = SIMD::fvecSize;
+    constexpr int l2Vecs   = L2_SIZE / F;
+    constexpr int headVecs = HEAD_SIZE / F;
+    static_assert(L2_SIZE % F == 0 && HEAD_SIZE % F == 0, "the head must tile the float vectors");
+
+    // L2, accumulated over inputs so the 32 outputs are one FMA per input
+    // rather than 32 dependent reductions.
+    SIMD::fvecType acc[l2Vecs];
+    for (int j = 0; j < l2Vecs; j++)
+        acc[j] = SIMD::fvecLoad(net.l2Biases + j * F);
+
+    // Skipping zero activations only pays when the loop body is wide enough to
+    // beat an unpredictable branch. On AVX-512 the body is two FMAs and the skip
+    // measured 1.3% slower, so it is off there.
+    constexpr bool skipZeros = l2Vecs >= 4;
 
     for (int c = 0; c < 2 * L1_SIZE; c++)
     {
-        const float  x = l1Activations[c];
-        const float* w = net.l2Weights[bucket][c];
-        for (int j = 0; j < L2_SIZE; j++)
-            head[j] += x * w[j];
+        if (skipZeros && l1Activations[c] == 0.0f)
+            continue;
+        const SIMD::fvecType a = SIMD::fvecSet1(l1Activations[c]);
+        const float*         w = net.l2Weights[c];
+        for (int j = 0; j < l2Vecs; j++)
+            acc[j] = SIMD::fvecFmadd(a, SIMD::fvecLoad(w + j * F), acc[j]);
     }
 
-    for (int j = 0; j < L2_SIZE; j++)
-        head[j] = screlu(head[j]);
+    const SIMD::fvecType zero = SIMD::fvecZero();
+    const SIMD::fvecType one  = SIMD::fvecSet1(1.0f);
 
-    // Skip connection: the output layer sees the L1 activations as well.
+    alignas(64) float head[HEAD_SIZE];
+    for (int j = 0; j < l2Vecs; j++)
+    {
+        const SIMD::fvecType clipped = SIMD::fvecMin(one, SIMD::fvecMax(zero, acc[j]));
+        SIMD::fvecStore(head + j * F, SIMD::fvecMul(clipped, clipped));
+    }
     std::memcpy(head + L2_SIZE, l1Activations, sizeof(l1Activations));
 
-    constexpr int LANES = 8;
-    static_assert(HEAD_SIZE % LANES == 0);
+    // Adjacent-pair reduction, so the summation order does not depend on the
+    // vector width.
+    SIMD::fvecType products[headVecs];
+    for (int k = 0; k < headVecs; k++)
+        products[k] = SIMD::fvecMul(SIMD::fvecLoad(head + k * F), SIMD::fvecLoad(net.l3Weights + k * F));
+    for (int width = headVecs; width > 1; width /= 2)
+        for (int k = 0; k < width / 2; k++)
+            products[k] = SIMD::fvecAdd(products[2 * k], products[2 * k + 1]);
 
-    float partial[LANES] = {};
-    for (int c = 0; c < HEAD_SIZE; c += LANES)
-        for (int lane = 0; lane < LANES; lane++)
-            partial[lane] += head[c + lane] * net.l3Weights[bucket][c + lane];
-
-    float output = net.l3Biases[bucket];
-    for (int lane = 0; lane < LANES; lane++)
-        output += partial[lane];
-
-    const int score = static_cast<int>(output * EVAL_SCALE);
+    const float output = net.l3Biases + SIMD::fvecReduceAdd(products[0]);
+    const int   score  = static_cast<int>(output * EVAL_SCALE);
     return std::clamp(score, -static_cast<int>(MAX_MATE_SCORE), static_cast<int>(MAX_MATE_SCORE));
 }
 
-/// Pairwise, side to move first, straight into the uint8 layout L1 wants. The
-/// product of two [0, 255] values fits a 16-bit lane, so a logical shift is the
-/// whole `>> INPUT_SHIFT` and nothing widens to int32.
-void NNUE::computePairwise(const int16_t* stm, const int16_t* nstm, uint8_t* out) {
-    const SIMD::vecType zero      = SIMD::vecZero();
-    const SIMD::vecType clip      = SIMD::vecSet1Epi16(static_cast<int16_t>(QA));
-    const SIMD::vecType roundBias = SIMD::vecSet1Epi16(1 << (INPUT_SHIFT - 1));
-
+void NNUE::computePairwise(const int16_t* stmPsq, const int16_t* stmTac, const int16_t* ntmPsq,
+                           const int16_t* ntmTac, uint8_t* out) {
+    const SIMD::vecType zero = SIMD::vecZero();
+    const SIMD::vecType clip = SIMD::vecSet1Epi16(static_cast<int16_t>(QA));
+    // TRUNCATE, do not round -- the trainer models it that way. Rounding reads
+    // ~40 cp high on lopsided positions.
     for (int perspective = 0; perspective < 2; perspective++)
     {
-        const int16_t* acc  = perspective == 0 ? stm : nstm;
+        const int16_t* accPsq = perspective == 0 ? stmPsq : ntmPsq;
+        const int16_t* accTac = perspective == 0 ? stmTac : ntmTac;
         uint8_t*       dest = out + perspective * PW;
 
         for (int i = 0; i < PW; i += 2 * SIMD::vecSize)
@@ -497,49 +762,105 @@ void NNUE::computePairwise(const int16_t* stm, const int16_t* nstm, uint8_t* out
             for (int half = 0; half < 2; half++)
             {
                 const int           at = i + half * SIMD::vecSize;
-                const SIMD::vecType lo = SIMD::vecMinEpi16(clip, SIMD::vecMaxEpi16(zero, SIMD::vecLoad(acc + at)));
-                const SIMD::vecType hi =
-                    SIMD::vecMinEpi16(clip, SIMD::vecMaxEpi16(zero, SIMD::vecLoad(acc + at + PW)));
-                products[half] =
-                    SIMD::vecSrliEpi16<INPUT_SHIFT>(SIMD::vecAddEpi16(SIMD::vecMulloEpi16(lo, hi), roundBias));
+                const SIMD::vecType rawLo = SIMD::vecAddEpi16(SIMD::vecLoad(accPsq + at), SIMD::vecLoad(accTac + at));
+                const SIMD::vecType rawHi =
+                    SIMD::vecAddEpi16(SIMD::vecLoad(accPsq + at + PW), SIMD::vecLoad(accTac + at + PW));
+                const SIMD::vecType lo = SIMD::vecMinEpi16(clip, SIMD::vecMaxEpi16(zero, rawLo));
+                const SIMD::vecType hi = SIMD::vecMinEpi16(clip, SIMD::vecMaxEpi16(zero, rawHi));
+                products[half] = SIMD::vecSrliEpi16<INPUT_SHIFT>(SIMD::vecMulloEpi16(lo, hi));
             }
             SIMD::vecStoreRaw(dest + i, SIMD::packUnsignedEpi16(products[0], products[1]));
         }
     }
 }
 
-/// Eight output neurons at a time: one reduction tree, shared input loads.
-void NNUE::l1Dots(const uint8_t* pairwise, int bucket, int32_t* dots) const {
-    const NetworkData&  net  = *network;
-    const SIMD::vecType ones = SIMD::vecSet1Epi16(1);
+namespace {
 
-    for (int group = 0; group < L1_SIZE; group += 8)
+// Set-bit positions per 8-bit mask, so the scan below is branchless: one
+// unaligned store, then advance by the popcount.
+alignas(64) constexpr auto NNZ_POSITIONS = [] {
+    std::array<std::array<uint16_t, 8>, 256> table{};
+    for (int mask = 0; mask < 256; mask++)
     {
-        SIMD::vecType sums[8];
-        for (int n = 0; n < 8; n++)
-            sums[n] = SIMD::vecZero();
+        int n = 0;
+        for (int bit = 0; bit < 8; bit++)
+            if (mask & (1 << bit))
+                table[mask][n++] = static_cast<uint16_t>(bit);
+    }
+    return table;
+}();
 
-        for (int c = 0; c < 2 * PW; c += SIMD::vecSize * 2)
+}  // namespace
+
+/// Sparse-input affine transform. Weights are input-group-major, so one 4-byte
+/// input group times one weight vector is a slice of every neuron at once and
+/// no horizontal reduction is needed. All-zero groups are skipped, which only
+/// pays because the net is exported with co-quiet outputs grouped together
+/// (tools/permute_net.py): 70% of groups live unordered, 54% ordered.
+void NNUE::l1Dots(const uint8_t* pairwise, int32_t* dots) const {
+    const NetworkData& net = *network;
+
+    // 16 lanes on AVX-512, 8 on AVX2, 4 on SSE.
+    constexpr int groupsPerVec = SIMD::vecSize / 2;
+    constexpr int nAcc         = L1_SIZE / groupsPerVec;
+    constexpr int maskBytes    = (groupsPerVec + 7) / 8;
+    constexpr int unroll       = 4 / nAcc;
+    static_assert(L1_SIZE % groupsPerVec == 0, "L1 must tile the accumulator vectors");
+
+    uint16_t nonZero[L1_GROUPS + 8];
+    int      count = 0;
+
+    for (int group = 0; group < L1_GROUPS; group += groupsPerVec)
+    {
+        uint32_t mask = SIMD::nonZeroMaskEpi32(SIMD::vecLoadRaw(pairwise + 4 * group));
+        for (int b = 0; b < maskBytes; b++)
         {
-            const SIMD::vecType inputs = SIMD::vecLoadRaw(pairwise + c);
-            for (int n = 0; n < 8; n++)
-            {
-                const SIMD::vecType w = SIMD::vecLoadRaw(net.l1Weights[bucket * L1_SIZE + group + n] + c);
-                sums[n] = SIMD::vecAddEpi32(sums[n], SIMD::vecMaddEpi16(SIMD::vecMaddubsEpi16(inputs, w), ones));
-            }
+            const uint8_t byte = static_cast<uint8_t>(mask >> (8 * b));
+            const __m128i base = _mm_set1_epi16(static_cast<int16_t>(group + 8 * b));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(nonZero + count),
+                             _mm_add_epi16(_mm_loadu_si128(reinterpret_cast<const __m128i*>(NNZ_POSITIONS[byte].data())), base));
+            count += __builtin_popcount(byte);
         }
+    }
 
-        SIMD::vecReduceEpi32x8(sums[0], sums[1], sums[2], sums[3], sums[4], sums[5], sums[6], sums[7], dots + group);
+    SIMD::vecType acc[unroll][nAcc];
+    for (int u = 0; u < unroll; u++)
+        for (int n = 0; n < nAcc; n++)
+            acc[u][n] = SIMD::vecZero();
+
+    auto step = [&](int u, int g) {
+        int32_t bytes;
+        std::memcpy(&bytes, pairwise + 4 * g, sizeof(bytes));
+        const SIMD::vecType inputs = SIMD::vecBroadcastEpi32(bytes);
+        for (int n = 0; n < nAcc; n++)
+            acc[u][n] = SIMD::vecDpbusdEpi32(acc[u][n], inputs,
+                                             SIMD::vecLoadRaw(net.l1Weights[g] + 4 * groupsPerVec * n));
+    };
+
+    int i = 0;
+    for (; i + unroll <= count; i += unroll)
+        for (int u = 0; u < unroll; u++)
+            step(u, nonZero[i + u]);
+    for (; i < count; i++)
+        step(0, nonZero[i]);
+
+    for (int n = 0; n < nAcc; n++)
+    {
+        SIMD::vecType sum = acc[0][n];
+        for (int u = 1; u < unroll; u++)
+            sum = SIMD::vecAddEpi32(sum, acc[u][n]);
+        SIMD::vecStoreEpi32(dots + groupsPerVec * n, sum);
     }
 }
 
-int NNUE::runHead(const int16_t* stm, const int16_t* nstm, int bucket) const {
+int NNUE::runHead(const int16_t* stmPsq, const int16_t* stmTac, const int16_t* ntmPsq,
+                  const int16_t* ntmTac) const {
     alignas(64) uint8_t pairwise[2 * PW];
     alignas(64) int32_t dots[L1_SIZE];
 
-    computePairwise(stm, nstm, pairwise);
-    l1Dots(pairwise, bucket, dots);
-    return finishHead(dots, bucket);
+    computePairwise(stmPsq, stmTac, ntmPsq, ntmTac, pairwise);
+    l1Dots(pairwise, dots);
+    return finishHead(dots);
 }
 
 // --- Evaluation -------------------------------------------------------------
@@ -550,11 +871,13 @@ void NNUE::calculateInputLayer(Board& board, int idx, bool fromScratch) {
 
     auto& acc = board.nnueData.accumulator[idx];
 
-    if (fromScratch || !acc.computed[WHITE] || !acc.computed[BLACK])
+    if (fromScratch || !acc.computedPsq[WHITE] || !acc.computedPsq[BLACK] || !acc.computedTac[WHITE]
+        || !acc.computedTac[BLACK])
     {
-        refresh(board, WHITE, acc.data[WHITE]);
-        refresh(board, BLACK, acc.data[BLACK]);
-        acc.computed[WHITE] = acc.computed[BLACK] = true;
+        refresh(board, WHITE, acc.psq[WHITE], acc.tac[WHITE]);
+        refresh(board, BLACK, acc.psq[BLACK], acc.tac[BLACK]);
+        acc.computedPsq[WHITE] = acc.computedPsq[BLACK] = true;
+        acc.computedTac[WHITE] = acc.computedTac[BLACK] = true;
     }
 
     acc.pawns[WHITE]  = board.bitboards[WHITE_PAWN];
@@ -570,7 +893,6 @@ int NNUE::evaluate(Board& board) {
 
     auto& acc = board.nnueData.accumulator[board.nnueData.size];
 
-    // makeMove fills this; it is missing only at a root set up without one.
     if (!acc.stateValid)
     {
         acc.pawns[WHITE]  = board.bitboards[WHITE_PAWN];
@@ -580,11 +902,12 @@ int NNUE::evaluate(Board& board) {
         acc.stateValid    = true;
     }
 
-
     updatePerspective(board, WHITE);
     updatePerspective(board, BLACK);
 
-    return runHead(acc.data[board.sideToMove], acc.data[~board.sideToMove], outputBucket(board));
+    const Color stm = board.sideToMove;
+    const Color ntm = ~stm;
+    return runHead(acc.psq[stm], acc.tac[stm], acc.psq[ntm], acc.tac[ntm]);
 }
 
 float NNUE::halfMoveScale(Board& board) { return (100.0f - board.halfMove) / 100.0f; }
@@ -617,7 +940,7 @@ bool NNUE::loadFromBuffer(const uint8_t* data, size_t size, const std::string& s
         return fail("shorter than the header");
 
     if (std::memcmp(data, MAGIC, sizeof(MAGIC)) != 0)
-        return fail("bad magic (expected DVNNUE4)");
+        return fail("bad magic (expected DVNNUE5)");
 
     auto expect = [&](const char* field, uint64_t got, uint64_t want, bool& ok) {
         if (got != want)
@@ -635,15 +958,14 @@ bool NNUE::loadFromBuffer(const uint8_t* data, size_t size, const std::string& s
     expect("pawnPairs", readU32(data, 24), PAWN_PAIRS, ok);
     expect("psqFeatures", readU32(data, 28), PSQ_FEATURES, ok);
     expect("inputQuant", readU32(data, 32), QA, ok);
-    expect("l1Quant", readU32(data, 36), L1_QUANT, ok);
+    expect("inputShift", readU32(data, 36), INPUT_SHIFT, ok);
     expect("l1Size", readU32(data, 40), L1_SIZE, ok);
     expect("l2Size", readU32(data, 44), L2_SIZE, ok);
     if (!ok)
         return fail("architecture mismatch");
 
-    // Not sizeof(NetworkData): the struct is padded to its alignment, the file
-    // is not.
-    constexpr size_t payload = sizeof(NetworkData::ftWeights) + sizeof(NetworkData::ftBiases)
+    constexpr size_t payload = sizeof(NetworkData::ftPsqWeights) + sizeof(NetworkData::ftTacWeights)
+                             + sizeof(NetworkData::ftTacBiases)
                              + sizeof(NetworkData::l1Weights) + sizeof(NetworkData::l1Norm)
                              + sizeof(NetworkData::l1Biases)
                              + sizeof(NetworkData::l2Weights) + sizeof(NetworkData::l2Biases)
@@ -663,32 +985,41 @@ bool NNUE::loadFromBuffer(const uint8_t* data, size_t size, const std::string& s
         src += bytes;
     };
 
-    read(net.ftWeights, sizeof(net.ftWeights));
-    read(net.ftBiases, sizeof(net.ftBiases));
-    read(net.l1Weights, sizeof(net.l1Weights));
+    read(net.ftPsqWeights, sizeof(net.ftPsqWeights));
+    read(net.ftTacWeights, sizeof(net.ftTacWeights));
+    read(net.ftTacBiases, sizeof(net.ftTacBiases));
+
+    // L1 arrives NEURON-major and is transposed to the input-group-major layout
+    // l1Dots consumes; see NetworkData::l1Weights.
+    {
+        std::vector<int8_t> raw(static_cast<size_t>(L1_SIZE) * 2 * PW);
+        read(raw.data(), raw.size());
+        for (int neuron = 0; neuron < L1_SIZE; neuron++)
+            for (int in = 0; in < 2 * PW; in++)
+                net.l1Weights[in / 4][4 * neuron + in % 4] = raw[static_cast<size_t>(neuron) * 2 * PW + in];
+    }
+
     read(net.l1Norm, sizeof(net.l1Norm));
     read(net.l1Biases, sizeof(net.l1Biases));
     read(net.l2Weights, sizeof(net.l2Weights));
     read(net.l2Biases, sizeof(net.l2Biases));
     read(net.l3Weights, sizeof(net.l3Weights));
-    read(net.l3Biases, sizeof(net.l3Biases));
+    read(&net.l3Biases, sizeof(net.l3Biases));
 
-    // L2 arrives output-major, evaluated input-major. Same bytes, so transpose
-    // in place.
-    for (int b = 0; b < OUTPUT_BUCKETS; b++)
+    // File is output-major; transpose to input-major so finishHead accumulates
+    // over inputs (one vector FMA per input, no serial reduction).
     {
         float raw[L2_SIZE][2 * L1_SIZE];
-        std::memcpy(raw, net.l2Weights[b], sizeof(raw));
-
+        std::memcpy(raw, net.l2Weights, sizeof(raw));
         for (int out = 0; out < L2_SIZE; out++)
             for (int in = 0; in < 2 * L1_SIZE; in++)
-                net.l2Weights[b][in][out] = raw[out][in];
+                net.l2Weights[in][out] = raw[out][in];
     }
 
     loaded = true;
 
-    std::cout << "info string Loaded net from " << sourceLabel << " (" << NNUE_FT_IN << " -> " << NNUE_FT_OUT
-              << ", " << KING_BUCKETS << " king buckets, " << PAWN_PAIRS << " pawn pairs, " << OUTPUT_BUCKETS
+    std::cout << "info string Loaded net from " << sourceLabel << " (" << FT_IN << " -> " << NNUE_FT_OUT
+              << ", " << KING_BUCKETS << " king buckets, " << NUM_TAC_FEATURES << " tactical features, " << OUTPUT_BUCKETS
               << " output buckets)" << std::endl;
     return true;
 }

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -21,7 +21,6 @@ INCBIN(EmbeddedNet, NET);
 namespace {
 
 // clang-format off
-// MUST match devre_threat.rs's expand_mirrored(KING_BUCKET_HALF).
 constexpr uint8_t KING_BUCKET_LAYOUT[64] = {
      0,  1,  2,  3,  3,  2,  1,  0,
      4,  5,  6,  7,  7,  6,  5,  4,
@@ -51,8 +50,6 @@ constexpr std::array<uint64_t, 8> ADJACENT_FILES = [] {
     return table;
 }();
 
-// --- Tactical Threat Tables (constexpr) -------------------------------------
-
 struct ThreatTables {
     int8_t   pawn_map[12];
     struct NonPkData {
@@ -71,33 +68,29 @@ struct ThreatTables {
             for (int p = 0; p < 4; p++) non_pk[p].targets[i] = -1;
         }
 
-        // Relative targets: 0..5 Friendly, 6..11 Enemy
-        // Pawn targets: Knight (1), Rook (3) -> Friendly 0, 1; Enemy 2, 3
+        // Relative targets: 0..5 friendly, 6..11 enemy; each piece maps its
+        // allowed victims onto a dense 0..N-1 id.
         pawn_map[1] = 0;
         pawn_map[3] = 1;
         pawn_map[7] = 2;
         pawn_map[9] = 3;
 
-        // Knight targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3), QUEEN(4) (N=5)
         non_pk[0].targets[0] = 0; non_pk[0].targets[6]  = 5;
         non_pk[0].targets[1] = 1; non_pk[0].targets[7]  = 6;
         non_pk[0].targets[2] = 2; non_pk[0].targets[8]  = 7;
         non_pk[0].targets[3] = 3; non_pk[0].targets[9]  = 8;
         non_pk[0].targets[4] = 4; non_pk[0].targets[10] = 9;
 
-        // Bishop targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3) (N=4)
         non_pk[1].targets[0] = 0; non_pk[1].targets[6]  = 4;
         non_pk[1].targets[1] = 1; non_pk[1].targets[7]  = 5;
         non_pk[1].targets[2] = 2; non_pk[1].targets[8]  = 6;
         non_pk[1].targets[3] = 3; non_pk[1].targets[9]  = 7;
 
-        // Rook targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3) (N=4)
         non_pk[2].targets[0] = 0; non_pk[2].targets[6]  = 4;
         non_pk[2].targets[1] = 1; non_pk[2].targets[7]  = 5;
         non_pk[2].targets[2] = 2; non_pk[2].targets[8]  = 6;
         non_pk[2].targets[3] = 3; non_pk[2].targets[9]  = 7;
 
-        // Queen targets: PAWN(0), KNIGHT(1), BISHOP(2), ROOK(3), QUEEN(4) (N=5)
         non_pk[3].targets[0] = 0; non_pk[3].targets[6]  = 5;
         non_pk[3].targets[1] = 1; non_pk[3].targets[7]  = 6;
         non_pk[3].targets[2] = 2; non_pk[3].targets[8]  = 7;
@@ -201,13 +194,29 @@ struct FlatThreatTable {
 };
 constexpr FlatThreatTable FLAT_THREAT_TABLE{};
 
+constexpr bool threatFeatureExists(int piece, int victim) {
+    for (int rel = 0; rel < 12; rel += 6)  // friendly, then enemy
+        for (int src = 0; src < 64; src++)
+            for (int dest = 0; dest < 64; dest++)
+                if (mapThreatSingle(THREAT_TABLES, piece, src, dest, victim + rel) >= 0)
+                    return true;
+    return false;
+}
+
+constexpr bool threatVictimsMatch() {
+    for (int p = 0; p < N_PIECE_TYPES; p++)
+        for (int v = 0; v < N_PIECE_TYPES; v++)
+            if (threatFeatureExists(p, v) != (((THREAT_VICTIMS[p] >> v) & 1) != 0))
+                return false;
+    return true;
+}
+static_assert(threatVictimsMatch(), "THREAT_VICTIMS disagrees with the threat index tables");
+
 // 480 KB, against 40 KB for computing the index on the fly; measured 5.7% faster.
 inline int mapThreatFast(int piece, int src, int dest, int target) {
     if (static_cast<unsigned>(piece) >= 5 || static_cast<unsigned>(target) >= 12) return -1;
     return FLAT_THREAT_TABLE.map[piece][src][dest][target];
 }
-
-// --- Accumulator arithmetic -------------------------------------------------
 
 // The psq half has no bias of its own; the FT bias lives in the tac half.
 alignas(64) constexpr int16_t ZERO_ACC[NNUE_FT_OUT] = {};
@@ -259,8 +268,6 @@ inline float screlu(float x) {
     return c * c;
 }
 
-// --- File format ------------------------------------------------------------
-
 constexpr char     MAGIC[8]    = {'D', 'V', 'N', 'N', 'U', 'E', '5', '\0'};
 constexpr uint32_t NET_VERSION = 1;
 constexpr size_t   HEADER_LEN  = 48;
@@ -279,8 +286,6 @@ NNUE::NNUE() {
     if (!loadFromBuffer(gEmbeddedNetData, gEmbeddedNetSize, "<embedded>"))
         std::cout << "info string No usable embedded net; set EvalFile" << std::endl;
 }
-
-// --- Feature indexing -------------------------------------------------------
 
 NNUE::PerspectiveKey NNUE::perspectiveKey(int kingSquare, Color perspective) {
     const int mirrored = (kingSquare & 7) > 3 ? 7 : 0;
@@ -305,22 +310,16 @@ int NNUE::pawnPairIndex(int idA, int idB) {
     return hi * (hi - 1) / 2 + lo;
 }
 
-// --- Full refresh -----------------------------------------------------------
-
 /// Rebuilds one or both halves; a nullptr skips that half, and skipping tac
 /// skips the threat generation, which is what a refresh actually costs.
-/// Rebuilds one or both halves; a nullptr skips that half, and skipping tac
-/// skips the threat generation, which is what a refresh actually costs.
-void NNUE::refresh(const Board& board, Color perspective, int16_t* psqOut, int16_t* tacOut) const {
-    const PerspectiveKey key = perspectiveKey(bitScanForward(board.bitboards[pieceIndex(perspective, KING)]),
-                                              perspective);
+void NNUE::refresh(const Board& board, Color perspective, PerspectiveKey key, int16_t* psqOut,
+                   int16_t* tacOut) const {
     if (psqOut)
         refreshPsq(board, perspective, key, psqOut);
     if (tacOut)
         refreshTac(board, perspective, key, tacOut);
 }
 
-/// One row per piece on the board.
 void NNUE::refreshPsq(const Board& board, Color perspective, PerspectiveKey key, int16_t* out) const {
     const NetworkData& net = *network;
 
@@ -346,44 +345,35 @@ void NNUE::refreshTac(const Board& board, Color perspective, PerspectiveKey key,
     const int8_t* tacRows[MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE];
     int           nTac = 0;
 
-    int pawnIds[16];
-    int pawnFiles[16];
-    int pawns = 0;
+    const Color    us   = perspective;
+    const int      flip = key.flip;
+    const uint64_t occ  = board.occupied[WHITE] | board.occupied[BLACK];
+    // Nothing threatens a king, so kings are never victims.
+    const uint64_t victims = occ & ~(board.bitboards[WHITE_KING] | board.bitboards[BLACK_KING]);
 
+    auto idOf = [&](int sq) {
+        return pawnId(sq, static_cast<Color>(pieceColor(board.pieceBoard[sq])), us, flip);
+    };
+
+    // Popping as we go leaves only the later pawns, so each pair is seen once.
     uint64_t pawnBB = board.bitboards[WHITE_PAWN] | board.bitboards[BLACK_PAWN];
     while (pawnBB)
     {
-        const int sq     = poplsb(pawnBB);
-        pawnIds[pawns]   = pawnId(sq, static_cast<Color>(pieceColor(board.pieceBoard[sq])), perspective, key.flip);
-        pawnFiles[pawns] = sq & 7;
-        pawns++;
+        const int sq  = poplsb(pawnBB);
+        const int idA = idOf(sq);
+
+        uint64_t partners = pawnBB & ADJACENT_FILES[fileIndex(sq)];
+        while (partners && nTac < MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE)
+        {
+            tacRows[nTac++] = net.ftTacWeights
+                            + static_cast<size_t>(pawnPairIndex(idA, idOf(poplsb(partners)))) * NNUE_FT_OUT;
+        }
     }
 
-    const uint64_t occ = board.occupied[WHITE] | board.occupied[BLACK];
-
-    // Pawn pairs
-    for (int i = 0; i < pawns; i++)
-        for (int j = i + 1; j < pawns; j++)
-            if (std::abs(pawnFiles[i] - pawnFiles[j]) <= 1)
-                if (nTac < MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE)
-                {
-                    tacRows[nTac++] = net.ftTacWeights
-                                    + static_cast<size_t>(pawnPairIndex(pawnIds[i], pawnIds[j]))
-                                          * NNUE_FT_OUT;
-                }
-
-    // Every (attacker, victim) pair on the board. Pairs the feature space does
+    // Every (attacker, victim) pair on the board; pairs the feature space does
     // not cover come back as -1 and are dropped.
-    const Color us        = perspective;
-    const int   ourKingSq = bitScanForward(board.bitboards[pieceIndex(us, KING)]);
-    const int   hFlip     = (ourKingSq % 8 > 3) ? 7 : 0;
-    const int   flip      = (us == WHITE) ? hFlip : (56 ^ hFlip);
-
-    /// Records the threat from `sq` onto whatever occupies `dest`.
     auto addThreat = [&](int piece, int sq, int dest, int offset) {
         const int victim = board.pieceBoard[dest];
-        if (victim >= N_PIECES)  // EMPTY, i.e. pieceBoard disagreeing with occupied
-            return;
         const int target = pieceType(victim) + (pieceColor(victim) == us ? 0 : 6);
         const int index  = mapThreatFast(piece, sq ^ flip, dest ^ flip, target);
         if (index >= 0 && nTac < MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE)
@@ -393,9 +383,8 @@ void NNUE::refreshTac(const Board& board, Color perspective, PerspectiveKey key,
         }
     };
 
-    /// Every occupied square `piece` on `sq` attacks.
     auto addThreatsFrom = [&](int piece, int sq, uint64_t attacks, int offset) {
-        uint64_t targets = attacks & occ;
+        uint64_t targets = attacks & victims;
         while (targets)
             addThreat(piece, sq, poplsb(targets), offset);
     };
@@ -411,8 +400,8 @@ void NNUE::refreshTac(const Board& board, Color perspective, PerspectiveKey key,
         const int      up    = (c == WHITE) ? 8 : -8;
         uint64_t       east  = pawns & ~FILE_H_BB;
         uint64_t       west  = pawns & ~FILE_A_BB;
-        east = ((c == WHITE) ? east << 9 : east >> 7) & occ;
-        west = ((c == WHITE) ? west << 7 : west >> 9) & occ;
+        east = ((c == WHITE) ? east << 9 : east >> 7) & victims;
+        west = ((c == WHITE) ? west << 7 : west >> 9) & victims;
         while (east)
         {
             const int dest = poplsb(east);
@@ -455,8 +444,6 @@ void NNUE::refreshTac(const Board& board, Color perspective, PerspectiveKey key,
 
     accumulateRows(out, net.ftTacBiases, tacRows, nTac, nullptr, 0);
 }
-
-// --- Incremental update -----------------------------------------------------
 
 /// doPsq / doTac are independent: the psq chain breaks on any king-key change,
 /// the tac chain only when the mirror flips.
@@ -535,54 +522,89 @@ void NNUE::pawnPairDelta(const uint64_t prevPawns[N_COLORS], const uint64_t curP
         return row;
     };
 
-    int removed[16], added[16];
-    int nRemoved = 0, nAdded = 0;
+    struct MovedPawn {
+        uint8_t id;
+        uint8_t file;
+    };
+
+    MovedPawn removed[16], added[16];
+    int       nRemoved = 0, nAdded = 0;
 
     for (int c = 0; c < N_COLORS; c++)
     {
+        const uint64_t diff = prevPawns[c] ^ curPawns[c];
+        if (!diff)
+            continue;
+
         const auto colour = static_cast<Color>(c);
 
-        uint64_t gone = prevPawns[c] & ~curPawns[c];
+        uint64_t gone = prevPawns[c] & diff;
         while (gone)
         {
             const int sq        = poplsb(gone);
-            removed[nRemoved++] = pawnId(sq, colour, perspective, key.flip) | ((sq & 7) << 8);
+            removed[nRemoved++] = {
+                static_cast<uint8_t>(pawnId(sq, colour, perspective, key.flip)),
+                static_cast<uint8_t>(fileIndex(sq))
+            };
         }
 
-        uint64_t fresh = curPawns[c] & ~prevPawns[c];
+        uint64_t fresh = curPawns[c] & diff;
         while (fresh)
         {
             const int sq    = poplsb(fresh);
-            added[nAdded++] = pawnId(sq, colour, perspective, key.flip) | ((sq & 7) << 8);
+            added[nAdded++] = {
+                static_cast<uint8_t>(pawnId(sq, colour, perspective, key.flip)),
+                static_cast<uint8_t>(fileIndex(sq))
+            };
         }
     }
 
-    const uint64_t keptWhite = prevPawns[WHITE] & curPawns[WHITE];
-    const uint64_t keptBlack = prevPawns[BLACK] & curPawns[BLACK];
+    const uint64_t keptPawns[N_COLORS] = {
+        prevPawns[WHITE] & curPawns[WHITE],
+        prevPawns[BLACK] & curPawns[BLACK]
+    };
 
-    auto pairsWithKept = [&](const int* moved, int count, const int8_t** rows, int& n) {
+    if (nRemoved == 1 && nAdded == 1 && removed[0].file == added[0].file)
+    {
+        const int      file  = removed[0].file;
+        const uint64_t adj   = ADJACENT_FILES[file];
+        const int      remId = removed[0].id;
+        const int      addId = added[0].id;
+
+        for (int c = 0; c < N_COLORS; c++)
+        {
+            uint64_t partners = keptPawns[c] & adj;
+            while (partners)
+            {
+                const int sq    = poplsb(partners);
+                const int pId   = pawnId(sq, static_cast<Color>(c), perspective, key.flip);
+                subRows[nSub++] = rowTac(pawnPairIndex(remId, pId));
+                addRows[nAdd++] = rowTac(pawnPairIndex(addId, pId));
+            }
+        }
+
+        return;
+    }
+
+    auto pairsWithKept = [&](const MovedPawn* moved, int count, const int8_t** rows, int& n) {
         for (int i = 0; i < count; i++)
         {
-            const int id   = moved[i] & 0xFF;
-            const int file = moved[i] >> 8;
+            const int id   = moved[i].id;
+            const int file = moved[i].file;
 
-            uint64_t partners = keptWhite & ADJACENT_FILES[file];
-            while (partners)
+            for (int c = 0; c < N_COLORS; c++)
             {
-                const int sq = poplsb(partners);
-                rows[n++]    = rowTac(pawnPairIndex(id, pawnId(sq, WHITE, perspective, key.flip)));
-            }
-
-            partners = keptBlack & ADJACENT_FILES[file];
-            while (partners)
-            {
-                const int sq = poplsb(partners);
-                rows[n++]    = rowTac(pawnPairIndex(id, pawnId(sq, BLACK, perspective, key.flip)));
+                uint64_t partners = keptPawns[c] & ADJACENT_FILES[file];
+                while (partners)
+                {
+                    const int sq = poplsb(partners);
+                    rows[n++]    = rowTac(pawnPairIndex(id, pawnId(sq, static_cast<Color>(c), perspective, key.flip)));
+                }
             }
 
             for (int j = i + 1; j < count; j++)
-                if (std::abs(file - (moved[j] >> 8)) <= 1)
-                    rows[n++] = rowTac(pawnPairIndex(id, moved[j] & 0xFF));
+                if (std::abs(file - moved[j].file) <= 1)
+                    rows[n++] = rowTac(pawnPairIndex(id, moved[j].id));
         }
     };
 
@@ -590,7 +612,9 @@ void NNUE::pawnPairDelta(const uint64_t prevPawns[N_COLORS], const uint64_t curP
     pairsWithKept(added, nAdded, addRows, nAdd);
 }
 
-void NNUE::refreshOnBucketChange(Board& board) const {
+/// `moved` is the side whose king may have changed square; the other side's
+/// key cannot have moved, so it stays on the incremental path.
+void NNUE::refreshOnBucketChange(Board& board, Color moved) const {
     if (!loaded)
         return;
 
@@ -599,26 +623,24 @@ void NNUE::refreshOnBucketChange(Board& board) const {
     if (cur == 0 || !stack[cur - 1].stateValid)
         return;
 
-    for (const Color p : {WHITE, BLACK})
+    const PerspectiveKey kNow  = perspectiveKey(stack[cur].kingSq[moved], moved);
+    const PerspectiveKey kPrev = perspectiveKey(stack[cur - 1].kingSq[moved], moved);
+    if (kNow == kPrev)
+        return;
+
+    if (kNow.flip != kPrev.flip)
     {
-        const PerspectiveKey kNow  = perspectiveKey(stack[cur].kingSq[p], p);
-        const PerspectiveKey kPrev = perspectiveKey(stack[cur - 1].kingSq[p], p);
-        if (kNow == kPrev)
-            continue;
-        if (kNow.flip != kPrev.flip)
-        {
-            // Mirror crossed: every feature index changes, both halves go.
-            refresh(board, p, stack[cur].psq[p], stack[cur].tac[p]);
-            stack[cur].computedTac[p] = true;
-        }
-        else
-        {
-            // Bucket only: tac indices depend on the mirror alone, so that half
-            // stays reachable. 90% of bucket changes land here.
-            refresh(board, p, stack[cur].psq[p], nullptr);
-        }
-        stack[cur].computedPsq[p] = true;
+        // Mirror crossed: every feature index changes, both halves go.
+        refresh(board, moved, kNow, stack[cur].psq[moved], stack[cur].tac[moved]);
+        stack[cur].computedTac[moved] = true;
     }
+    else
+    {
+        // Bucket only: tac indices depend on the mirror alone, so that half
+        // stays reachable. 90% of bucket changes land here.
+        refresh(board, moved, kNow, stack[cur].psq[moved], nullptr);
+    }
+    stack[cur].computedPsq[moved] = true;
 }
 
 void NNUE::updatePerspective(Board& board, Color perspective) const {
@@ -630,8 +652,7 @@ void NNUE::updatePerspective(Board& board, Color perspective) const {
     if (!needPsq && !needTac)
         return;
 
-    const PerspectiveKey key = perspectiveKey(bitScanForward(board.bitboards[pieceIndex(perspective, KING)]),
-                                              perspective);
+    const PerspectiveKey key = perspectiveKey(stack[cur].kingSq[perspective], perspective);
 
     int basePsq = -1;
     if (needPsq)
@@ -662,12 +683,12 @@ void NNUE::updatePerspective(Board& board, Color perspective) const {
 
     if (needPsq && basePsq < 0)
     {
-        refresh(board, perspective, stack[cur].psq[perspective], nullptr);
+        refresh(board, perspective, key, stack[cur].psq[perspective], nullptr);
         stack[cur].computedPsq[perspective] = true;
     }
     if (needTac && baseTac < 0)
     {
-        refresh(board, perspective, nullptr, stack[cur].tac[perspective]);
+        refresh(board, perspective, key, nullptr, stack[cur].tac[perspective]);
         stack[cur].computedTac[perspective] = true;
     }
 
@@ -678,8 +699,6 @@ void NNUE::updatePerspective(Board& board, Color perspective) const {
     for (int i = std::min(fromPsq, fromTac); i <= cur; i++)
         applyPly(board, perspective, i, key, i >= fromPsq, i >= fromTac);
 }
-
-// --- Head -------------------------------------------------------------------
 
 int NNUE::finishHead(const int32_t* l1Dots) const {
     const NetworkData& net = *network;
@@ -863,8 +882,6 @@ int NNUE::runHead(const int16_t* stmPsq, const int16_t* stmTac, const int16_t* n
     return finishHead(dots);
 }
 
-// --- Evaluation -------------------------------------------------------------
-
 void NNUE::calculateInputLayer(Board& board, int idx, bool fromScratch) {
     if (!loaded)
         return;
@@ -874,8 +891,9 @@ void NNUE::calculateInputLayer(Board& board, int idx, bool fromScratch) {
     if (fromScratch || !acc.computedPsq[WHITE] || !acc.computedPsq[BLACK] || !acc.computedTac[WHITE]
         || !acc.computedTac[BLACK])
     {
-        refresh(board, WHITE, acc.psq[WHITE], acc.tac[WHITE]);
-        refresh(board, BLACK, acc.psq[BLACK], acc.tac[BLACK]);
+        for (const Color p : {WHITE, BLACK})
+            refresh(board, p, perspectiveKey(bitScanForward(board.bitboards[pieceIndex(p, KING)]), p),
+                    acc.psq[p], acc.tac[p]);
         acc.computedPsq[WHITE] = acc.computedPsq[BLACK] = true;
         acc.computedTac[WHITE] = acc.computedTac[BLACK] = true;
     }
@@ -926,8 +944,6 @@ float NNUE::materialScale(Board& board) {
 
     return a + (b - a) * gamePhase / 64.0f;
 }
-
-// --- Loading ----------------------------------------------------------------
 
 bool NNUE::loadFromBuffer(const uint8_t* data, size_t size, const std::string& sourceLabel) {
     auto fail = [&](const std::string& message) {

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -11,34 +11,51 @@
 
 class NNUE {
    public:
-    static constexpr int KING_BUCKETS   = 12;
-    static constexpr int PSQ_FEATURES   = 768 * KING_BUCKETS;            // 9216
-    static constexpr int PAWN_IDS       = 96;                            // 48 friendly + 48 enemy
-    static constexpr int PAWN_PAIRS     = PAWN_IDS * (PAWN_IDS - 1) / 2; // 4560
-    static constexpr int PW             = NNUE_FT_OUT / 2;
+    // --- Input space. Two disjoint blocks feeding one shared accumulator. ------
+    static constexpr int KING_BUCKETS     = 12;
+    static constexpr int PSQ_FEATURES     = 768 * KING_BUCKETS;              // 9216
+    static constexpr int PAWN_IDS         = 96;                              // 48 friendly + 48 enemy
+    static constexpr int PAWN_PAIRS       = PAWN_IDS * (PAWN_IDS - 1) / 2;   // 4560
+    static constexpr int NUM_THREATS      = 59808;
+    static constexpr int NUM_TAC_FEATURES = PAWN_PAIRS + NUM_THREATS;        // 64368
+    static constexpr int FT_IN            = PSQ_FEATURES + NUM_TAC_FEATURES; // 73584
+
+    // --- Head. FT -> pairwise -> L1 -> L2 -> scalar. ---------------------------
+    static constexpr int PW             = NNUE_FT_OUT / 2;         // 384 pairwise outputs
     static constexpr int L1_SIZE        = 16;
     static constexpr int L2_SIZE        = 32;
-    static constexpr int HEAD_SIZE      = L2_SIZE + 2 * L1_SIZE;         // 64, [L2 act | L1 act]
-    static constexpr int OUTPUT_BUCKETS = 8;
+    static constexpr int HEAD_SIZE      = L2_SIZE + 2 * L1_SIZE;   // 64, [L2 act | L1 act]
+    // The L1 input is consumed as 4-byte groups, the unit one dpbusd lane eats.
+    static constexpr int L1_GROUPS      = 2 * PW / 4;              // 192
+    static constexpr int OUTPUT_BUCKETS = 1;
+    static constexpr int EVAL_SCALE     = 400;
+    static constexpr int QA          = 127;  // FT / accumulator scale (int8 weights)
+    static constexpr int INPUT_SHIFT = 7;    // pairwise right shift (127*127 >> 7 = 126)
 
-    static constexpr int QA          = 127;  // FT / accumulator scale
-    static constexpr int INPUT_SHIFT = 7;    // pairwise right shift
-    static constexpr int L1_QUANT    = 64;   // int8 L1 weight scale
+    static constexpr int MAX_PSQ_ACTIVE    = 32;
+    static constexpr int MAX_PAIR_ACTIVE   = 96;
+    static constexpr int MAX_THREAT_ACTIVE = 128;
+    static constexpr int MAX_ACTIVE        = MAX_PSQ_ACTIVE + MAX_PAIR_ACTIVE + MAX_THREAT_ACTIVE;
+    static_assert(QA + MAX_ACTIVE * 127 <= 32767, "int16 FT accumulator can overflow");
+    static_assert((QA * QA >> INPUT_SHIFT) <= 127, "pairwise output must fit int8");
 
-    static_assert(NNUE_FT_IN == PSQ_FEATURES + PAWN_PAIRS, "input space must be psq + pawn pairs");
     static_assert(NNUE_FT_OUT % 2 == 0, "the pairwise stage halves the accumulator");
+    static_assert(2 * PW % 4 == 0, "the L1 input must split into whole 4-byte groups");
 
    private:
     struct NetworkData {
-        alignas(64) int8_t  ftWeights[static_cast<size_t>(NNUE_FT_IN) * NNUE_FT_OUT];
-        alignas(64) int16_t ftBiases[NNUE_FT_OUT];
-        alignas(64) int8_t  l1Weights[OUTPUT_BUCKETS * L1_SIZE][2 * PW];
-        alignas(64) float   l1Norm[OUTPUT_BUCKETS * L1_SIZE];
-        alignas(64) float   l1Biases[OUTPUT_BUCKETS * L1_SIZE];
-        alignas(64) float   l2Weights[OUTPUT_BUCKETS][2 * L1_SIZE][L2_SIZE];
-        alignas(64) float   l2Biases[OUTPUT_BUCKETS * L2_SIZE];
-        alignas(64) float   l3Weights[OUTPUT_BUCKETS][HEAD_SIZE];
-        alignas(64) float   l3Biases[OUTPUT_BUCKETS];
+        alignas(64) int8_t  ftPsqWeights[static_cast<size_t>(PSQ_FEATURES) * NNUE_FT_OUT];
+        alignas(64) int8_t  ftTacWeights[static_cast<size_t>(NUM_TAC_FEATURES) * NNUE_FT_OUT];
+        alignas(64) int16_t ftTacBiases[NNUE_FT_OUT];
+        // Input-group-major: l1Weights[g][4 * out + k] is the weight from input
+        // 4 * g + k to neuron `out`. See l1Dots for why.
+        alignas(64) int8_t  l1Weights[L1_GROUPS][4 * L1_SIZE];
+        alignas(64) float   l1Norm[L1_SIZE];
+        alignas(64) float   l1Biases[L1_SIZE];
+        alignas(64) float   l2Weights[L2_SIZE][2 * L1_SIZE];
+        alignas(64) float   l2Biases[L2_SIZE];
+        alignas(64) float   l3Weights[HEAD_SIZE];
+        alignas(64) float   l3Biases;
     };
 
     struct PerspectiveKey {
@@ -56,19 +73,23 @@ class NNUE {
 
     static PerspectiveKey perspectiveKey(int kingSquare, Color perspective);
 
-    void refresh(const Board& board, Color perspective, int16_t* accumulator) const;
-    void refreshFromCache(Board& board, Color perspective, PerspectiveKey key, int16_t* accumulator) const;
+    void refresh(const Board& board, Color perspective, int16_t* psqOut, int16_t* tacOut) const;
+    void refreshPsq(const Board& board, Color perspective, PerspectiveKey key, int16_t* out) const;
+    void refreshTac(const Board& board, Color perspective, PerspectiveKey key, int16_t* out) const;
+
     void updatePerspective(Board& board, Color perspective) const;
-    void applyPly(Board& board, Color perspective, int idx, PerspectiveKey key) const;
+    void applyPly(Board& board, Color perspective, int idx, PerspectiveKey key, bool doPsq, bool doTac) const;
 
     void pawnPairDelta(const uint64_t prevPawns[N_COLORS], const uint64_t curPawns[N_COLORS], Color perspective,
                        PerspectiveKey key, const int8_t** addRows, int& nAdd, const int8_t** subRows,
                        int& nSub) const;
 
-    static void computePairwise(const int16_t* stm, const int16_t* nstm, uint8_t* out);
-    void        l1Dots(const uint8_t* pairwise, int bucket, int32_t* dots) const;
-    int         finishHead(const int32_t* dots, int bucket) const;
-    int         runHead(const int16_t* stm, const int16_t* nstm, int bucket) const;
+    static void computePairwise(const int16_t* stmPsq, const int16_t* stmTac, const int16_t* ntmPsq,
+                                const int16_t* ntmTac, uint8_t* out);
+    void        l1Dots(const uint8_t* pairwise, int32_t* dots) const;
+    int         finishHead(const int32_t* dots) const;
+    int         runHead(const int16_t* stmPsq, const int16_t* stmTac, const int16_t* ntmPsq,
+                        const int16_t* ntmTac) const;
 
     bool loadFromBuffer(const uint8_t* data, size_t size, const std::string& sourceLabel);
 
@@ -77,10 +98,14 @@ class NNUE {
     static int psqFeature(int piece, int square, Color perspective, PerspectiveKey key);
     static int pawnId(int square, Color pawnColor, Color perspective, int flip);
     static int pawnPairIndex(int idA, int idB);
-    static int outputBucket(const Board& board);
 
     static float materialScale(Board& board);
     static float halfMoveScale(Board& board);
+
+    // Called from makeMove, the last point where the node's board state exists,
+    // so the whole subtree below can delta from here instead of each leaf
+    // rebuilding from the bias.
+    void refreshOnBucketChange(Board& board) const;
 
     void calculateInputLayer(Board& board, int idx, bool fromScratch = false);
     int evaluate(Board& board);

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -11,7 +11,7 @@
 
 class NNUE {
    public:
-    // --- Input space. Two disjoint blocks feeding one shared accumulator. ------
+    // Input space: two disjoint blocks feeding one shared accumulator.
     static constexpr int KING_BUCKETS     = 12;
     static constexpr int PSQ_FEATURES     = 768 * KING_BUCKETS;              // 9216
     static constexpr int PAWN_IDS         = 96;                              // 48 friendly + 48 enemy
@@ -20,7 +20,7 @@ class NNUE {
     static constexpr int NUM_TAC_FEATURES = PAWN_PAIRS + NUM_THREATS;        // 64368
     static constexpr int FT_IN            = PSQ_FEATURES + NUM_TAC_FEATURES; // 73584
 
-    // --- Head. FT -> pairwise -> L1 -> L2 -> scalar. ---------------------------
+    // Head: FT -> pairwise -> L1 -> L2 -> scalar.
     static constexpr int PW             = NNUE_FT_OUT / 2;         // 384 pairwise outputs
     static constexpr int L1_SIZE        = 16;
     static constexpr int L2_SIZE        = 32;
@@ -47,8 +47,6 @@ class NNUE {
         alignas(64) int8_t  ftPsqWeights[static_cast<size_t>(PSQ_FEATURES) * NNUE_FT_OUT];
         alignas(64) int8_t  ftTacWeights[static_cast<size_t>(NUM_TAC_FEATURES) * NNUE_FT_OUT];
         alignas(64) int16_t ftTacBiases[NNUE_FT_OUT];
-        // Input-group-major: l1Weights[g][4 * out + k] is the weight from input
-        // 4 * g + k to neuron `out`. See l1Dots for why.
         alignas(64) int8_t  l1Weights[L1_GROUPS][4 * L1_SIZE];
         alignas(64) float   l1Norm[L1_SIZE];
         alignas(64) float   l1Biases[L1_SIZE];
@@ -73,7 +71,8 @@ class NNUE {
 
     static PerspectiveKey perspectiveKey(int kingSquare, Color perspective);
 
-    void refresh(const Board& board, Color perspective, int16_t* psqOut, int16_t* tacOut) const;
+    void refresh(const Board& board, Color perspective, PerspectiveKey key, int16_t* psqOut,
+                 int16_t* tacOut) const;
     void refreshPsq(const Board& board, Color perspective, PerspectiveKey key, int16_t* out) const;
     void refreshTac(const Board& board, Color perspective, PerspectiveKey key, int16_t* out) const;
 
@@ -105,7 +104,7 @@ class NNUE {
     // Called from makeMove, the last point where the node's board state exists,
     // so the whole subtree below can delta from here instead of each leaf
     // rebuilding from the bias.
-    void refreshOnBucketChange(Board& board) const;
+    void refreshOnBucketChange(Board& board, Color moved) const;
 
     void calculateInputLayer(Board& board, int idx, bool fromScratch = false);
     int evaluate(Board& board);

--- a/src/simd.h
+++ b/src/simd.h
@@ -16,7 +16,6 @@ inline vecType vecSubEpi16(vecType a, vecType b) { return _mm512_sub_epi16(a, b)
 inline vecType vecMaxEpi16(vecType a, vecType b) { return _mm512_max_epi16(a, b); }
 inline vecType vecMinEpi16(vecType a, vecType b) { return _mm512_min_epi16(a, b); }
 inline vecType vecZero() { return _mm512_setzero_si512(); }
-inline vecType vecMaddEpi16(vecType a, vecType b) { return _mm512_madd_epi16(a, b); }
 inline vecType vecMulloEpi16(vecType a, vecType b) { return _mm512_mullo_epi16(a, b); }
 inline vecType vecAddEpi32(vecType a, vecType b) { return _mm512_add_epi32(a, b); }
 inline vecType vecSet1Epi16(int16_t a) { return _mm512_set1_epi16(a); }
@@ -25,40 +24,42 @@ inline void vecStore(int16_t* p, vecType v) { _mm512_store_si512(reinterpret_cas
 inline vecType vecLoadI8ToI16(const int8_t* p) {
     return _mm512_cvtepi8_epi16(_mm256_load_si256(reinterpret_cast<const __m256i*>(p)));
 }
-inline int vecReduceEpi32(vecType a) { return _mm512_reduce_add_epi32(a); }
+inline vecType vecBroadcastEpi32(int32_t a) { return _mm512_set1_epi32(a); }
+inline void vecStoreEpi32(int32_t* p, vecType v) { _mm512_store_si512(reinterpret_cast<void*>(p), v); }
+inline uint32_t nonZeroMaskEpi32(vecType v) { return _mm512_test_epi32_mask(v, v); }
+inline vecType vecDpbusdEpi32(vecType acc, vecType a, vecType b) {
+#if defined(__AVX512VNNI__)
+    return _mm512_dpbusd_epi32(acc, a, b);
+#else
+    return _mm512_add_epi32(acc, _mm512_madd_epi16(_mm512_maddubs_epi16(a, b), _mm512_set1_epi16(1)));
+#endif
+}
 
-// --- Ops used by the NNUE head. ---------------------------------------------
-// `packUnsignedEpi16` keeps the LOGICAL element order: the hardware pack
-// instructions interleave 128-bit lanes, so each one needs a permute afterwards.
+// packUnsignedEpi16 keeps logical element order; the hardware pack interleaves
+// 128-bit lanes, hence the permute.
 template<int N>
 inline vecType vecSrliEpi16(vecType a) { return _mm512_srli_epi16(a, N); }
 inline vecType packUnsignedEpi16(vecType a, vecType b) {
     const __m512i order = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
     return _mm512_permutexvar_epi64(order, _mm512_packus_epi16(a, b));
 }
-inline vecType vecMaddubsEpi16(vecType u8, vecType i8) { return _mm512_maddubs_epi16(u8, i8); }
 inline vecType vecLoadRaw(const void* p) { return _mm512_load_si512(p); }
 inline void vecStoreRaw(void* p, vecType v) { _mm512_store_si512(p, v); }
 
-// Horizontal sums of eight vectors at once via a hadd tree; out[i] receives the
-// lane sum of vector i. Wrap-around int32 addition makes the result identical
-// to eight separate vecReduceEpi32 calls.
-inline void vecReduceEpi32x8(vecType a0, vecType a1, vecType a2, vecType a3, vecType a4, vecType a5, vecType a6, vecType a7, int32_t* out) {
-    const __m256i h0 = _mm256_add_epi32(_mm512_castsi512_si256(a0), _mm512_extracti64x4_epi64(a0, 1));
-    const __m256i h1 = _mm256_add_epi32(_mm512_castsi512_si256(a1), _mm512_extracti64x4_epi64(a1, 1));
-    const __m256i h2 = _mm256_add_epi32(_mm512_castsi512_si256(a2), _mm512_extracti64x4_epi64(a2, 1));
-    const __m256i h3 = _mm256_add_epi32(_mm512_castsi512_si256(a3), _mm512_extracti64x4_epi64(a3, 1));
-    const __m256i h4 = _mm256_add_epi32(_mm512_castsi512_si256(a4), _mm512_extracti64x4_epi64(a4, 1));
-    const __m256i h5 = _mm256_add_epi32(_mm512_castsi512_si256(a5), _mm512_extracti64x4_epi64(a5, 1));
-    const __m256i h6 = _mm256_add_epi32(_mm512_castsi512_si256(a6), _mm512_extracti64x4_epi64(a6, 1));
-    const __m256i h7 = _mm256_add_epi32(_mm512_castsi512_si256(a7), _mm512_extracti64x4_epi64(a7, 1));
+// --- float ops for the head -------------------------------------------------
+using fvecType = __m512;
+constexpr int fvecSize = 16;
 
-    const __m256i u0 = _mm256_hadd_epi32(_mm256_hadd_epi32(h0, h1), _mm256_hadd_epi32(h2, h3));
-    const __m256i u1 = _mm256_hadd_epi32(_mm256_hadd_epi32(h4, h5), _mm256_hadd_epi32(h6, h7));
-
-    const __m256i sums = _mm256_add_epi32(_mm256_permute2x128_si256(u0, u1, 0x20), _mm256_permute2x128_si256(u0, u1, 0x31));
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), sums);
-}
+inline fvecType fvecZero() { return _mm512_setzero_ps(); }
+inline fvecType fvecSet1(float a) { return _mm512_set1_ps(a); }
+inline fvecType fvecLoad(const float* p) { return _mm512_load_ps(p); }
+inline void fvecStore(float* p, fvecType v) { _mm512_store_ps(p, v); }
+inline fvecType fvecAdd(fvecType a, fvecType b) { return _mm512_add_ps(a, b); }
+inline fvecType fvecMul(fvecType a, fvecType b) { return _mm512_mul_ps(a, b); }
+inline fvecType fvecFmadd(fvecType a, fvecType b, fvecType c) { return _mm512_fmadd_ps(a, b, c); }
+inline fvecType fvecMin(fvecType a, fvecType b) { return _mm512_min_ps(a, b); }
+inline fvecType fvecMax(fvecType a, fvecType b) { return _mm512_max_ps(a, b); }
+inline float fvecReduceAdd(fvecType v) { return _mm512_reduce_add_ps(v); }
 
 #elif defined(__AVX2__)
 
@@ -70,7 +71,6 @@ inline vecType vecSubEpi16(vecType a, vecType b) { return _mm256_sub_epi16(a, b)
 inline vecType vecMaxEpi16(vecType a, vecType b) { return _mm256_max_epi16(a, b); }
 inline vecType vecMinEpi16(vecType a, vecType b) { return _mm256_min_epi16(a, b); }
 inline vecType vecZero() { return _mm256_setzero_si256(); }
-inline vecType vecMaddEpi16(vecType a, vecType b) { return _mm256_madd_epi16(a, b); }
 inline vecType vecMulloEpi16(vecType a, vecType b) { return _mm256_mullo_epi16(a, b); }
 inline vecType vecAddEpi32(vecType a, vecType b) { return _mm256_add_epi32(a, b); }
 inline vecType vecSet1Epi16(int16_t a) { return _mm256_set1_epi16(a); }
@@ -79,34 +79,52 @@ inline void vecStore(int16_t* p, vecType v) { _mm256_store_si256(reinterpret_cas
 inline vecType vecLoadI8ToI16(const int8_t* p) {
     return _mm256_cvtepi8_epi16(_mm_load_si128(reinterpret_cast<const __m128i*>(p)));
 }
-inline int vecReduceEpi32(vecType sum) {
-    __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
-    sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
-    sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
-    return _mm_cvtsi128_si32(sum128);
+inline vecType vecBroadcastEpi32(int32_t a) { return _mm256_set1_epi32(a); }
+inline void vecStoreEpi32(int32_t* p, vecType v) { _mm256_store_si256(reinterpret_cast<__m256i*>(p), v); }
+inline uint32_t nonZeroMaskEpi32(vecType v) {
+    const __m256i isZero = _mm256_cmpeq_epi32(v, _mm256_setzero_si256());
+    return static_cast<uint32_t>(~_mm256_movemask_ps(_mm256_castsi256_ps(isZero))) & 0xFFu;
 }
 
-// --- Ops used by the NNUE head. ---------------------------------------------
-// `packUnsignedEpi16` keeps the LOGICAL element order: `packus` packs each
-// 128-bit lane of a and b separately, so the halves need swapping back.
 template<int N>
 inline vecType vecSrliEpi16(vecType a) { return _mm256_srli_epi16(a, N); }
 inline vecType packUnsignedEpi16(vecType a, vecType b) {
     return _mm256_permute4x64_epi64(_mm256_packus_epi16(a, b), 0xD8);
 }
-inline vecType vecMaddubsEpi16(vecType u8, vecType i8) { return _mm256_maddubs_epi16(u8, i8); }
 inline vecType vecLoadRaw(const void* p) { return _mm256_load_si256(reinterpret_cast<const __m256i*>(p)); }
+inline vecType vecDpbusdEpi32(vecType acc, vecType a, vecType b) {
+#if (defined(__AVX512VNNI__) && defined(__AVX512VL__)) || defined(__AVXVNNI__)
+    return _mm256_dpbusd_epi32(acc, a, b);
+#else
+    return _mm256_add_epi32(acc, _mm256_madd_epi16(_mm256_maddubs_epi16(a, b), _mm256_set1_epi16(1)));
+#endif
+}
 inline void vecStoreRaw(void* p, vecType v) { _mm256_store_si256(reinterpret_cast<__m256i*>(p), v); }
 
-// Horizontal sums of eight vectors at once via a hadd tree; out[i] receives the
-// lane sum of vector i. Wrap-around int32 addition makes the result identical
-// to eight separate vecReduceEpi32 calls.
-inline void vecReduceEpi32x8(vecType a0, vecType a1, vecType a2, vecType a3, vecType a4, vecType a5, vecType a6, vecType a7, int32_t* out) {
-    const __m256i u0 = _mm256_hadd_epi32(_mm256_hadd_epi32(a0, a1), _mm256_hadd_epi32(a2, a3));
-    const __m256i u1 = _mm256_hadd_epi32(_mm256_hadd_epi32(a4, a5), _mm256_hadd_epi32(a6, a7));
+// --- float ops for the head -------------------------------------------------
+using fvecType = __m256;
+constexpr int fvecSize = 8;
 
-    const __m256i sums = _mm256_add_epi32(_mm256_permute2x128_si256(u0, u1, 0x20), _mm256_permute2x128_si256(u0, u1, 0x31));
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), sums);
+inline fvecType fvecZero() { return _mm256_setzero_ps(); }
+inline fvecType fvecSet1(float a) { return _mm256_set1_ps(a); }
+inline fvecType fvecLoad(const float* p) { return _mm256_load_ps(p); }
+inline void fvecStore(float* p, fvecType v) { _mm256_store_ps(p, v); }
+inline fvecType fvecAdd(fvecType a, fvecType b) { return _mm256_add_ps(a, b); }
+inline fvecType fvecMul(fvecType a, fvecType b) { return _mm256_mul_ps(a, b); }
+inline fvecType fvecFmadd(fvecType a, fvecType b, fvecType c) {
+#if defined(__FMA__)
+    return _mm256_fmadd_ps(a, b, c);
+#else
+    return _mm256_add_ps(_mm256_mul_ps(a, b), c);
+#endif
+}
+inline fvecType fvecMin(fvecType a, fvecType b) { return _mm256_min_ps(a, b); }
+inline fvecType fvecMax(fvecType a, fvecType b) { return _mm256_max_ps(a, b); }
+inline float fvecReduceAdd(fvecType v) {
+    __m128 half = _mm_add_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+    half = _mm_add_ps(half, _mm_movehl_ps(half, half));
+    half = _mm_add_ss(half, _mm_shuffle_ps(half, half, 1));
+    return _mm_cvtss_f32(half);
 }
 
 #else
@@ -119,7 +137,6 @@ inline vecType vecSubEpi16(vecType a, vecType b) { return _mm_sub_epi16(a, b); }
 inline vecType vecMaxEpi16(vecType a, vecType b) { return _mm_max_epi16(a, b); }
 inline vecType vecMinEpi16(vecType a, vecType b) { return _mm_min_epi16(a, b); }
 inline vecType vecZero() { return _mm_setzero_si128(); }
-inline vecType vecMaddEpi16(vecType a, vecType b) { return _mm_madd_epi16(a, b); }
 inline vecType vecMulloEpi16(vecType a, vecType b) { return _mm_mullo_epi16(a, b); }
 inline vecType vecAddEpi32(vecType a, vecType b) { return _mm_add_epi32(a, b); }
 inline vecType vecSet1Epi16(int16_t a) { return _mm_set1_epi16(a); }
@@ -130,36 +147,58 @@ inline vecType vecLoadI8ToI16(const int8_t* p) {
     const __m128i sign = _mm_cmpgt_epi8(_mm_setzero_si128(), bytes);
     return _mm_unpacklo_epi8(bytes, sign);
 }
-inline int vecReduceEpi32(vecType sum) {
-    sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E));
-    sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1));
-    return _mm_cvtsi128_si32(sum);
+inline vecType vecBroadcastEpi32(int32_t a) { return _mm_set1_epi32(a); }
+inline void vecStoreEpi32(int32_t* p, vecType v) { _mm_store_si128(reinterpret_cast<__m128i*>(p), v); }
+inline uint32_t nonZeroMaskEpi32(vecType v) {
+    const __m128i isZero = _mm_cmpeq_epi32(v, _mm_setzero_si128());
+    return static_cast<uint32_t>(~_mm_movemask_ps(_mm_castsi128_ps(isZero))) & 0xFu;
 }
 
-// --- Ops used by the NNUE head. ---------------------------------------------
-// A single 128-bit lane needs no permute after packing. `maddubs` is SSSE3, so
-// a plain SSE2 build gets the scalar head instead.
 template<int N>
 inline vecType vecSrliEpi16(vecType a) { return _mm_srli_epi16(a, N); }
 inline vecType packUnsignedEpi16(vecType a, vecType b) { return _mm_packus_epi16(a, b); }
 inline vecType vecLoadRaw(const void* p) { return _mm_load_si128(reinterpret_cast<const __m128i*>(p)); }
 inline void vecStoreRaw(void* p, vecType v) { _mm_store_si128(reinterpret_cast<__m128i*>(p), v); }
-#if defined(__SSSE3__)
-inline vecType vecMaddubsEpi16(vecType u8, vecType i8) { return _mm_maddubs_epi16(u8, i8); }
-#else
-    #error "Devre's NNUE head requires SSSE3 or better (build=ssse3, avx2, avx512 or native)"
-#endif
 
-// SSE2 has no hadd; plain per-vector reductions keep this path simple.
-inline void vecReduceEpi32x8(vecType a0, vecType a1, vecType a2, vecType a3, vecType a4, vecType a5, vecType a6, vecType a7, int32_t* out) {
-    out[0] = vecReduceEpi32(a0);
-    out[1] = vecReduceEpi32(a1);
-    out[2] = vecReduceEpi32(a2);
-    out[3] = vecReduceEpi32(a3);
-    out[4] = vecReduceEpi32(a4);
-    out[5] = vecReduceEpi32(a5);
-    out[6] = vecReduceEpi32(a6);
-    out[7] = vecReduceEpi32(a7);
+// --- float ops for the head -------------------------------------------------
+using fvecType = __m128;
+constexpr int fvecSize = 4;
+
+inline fvecType fvecZero() { return _mm_setzero_ps(); }
+inline fvecType fvecSet1(float a) { return _mm_set1_ps(a); }
+inline fvecType fvecLoad(const float* p) { return _mm_load_ps(p); }
+inline void fvecStore(float* p, fvecType v) { _mm_store_ps(p, v); }
+inline fvecType fvecAdd(fvecType a, fvecType b) { return _mm_add_ps(a, b); }
+inline fvecType fvecMul(fvecType a, fvecType b) { return _mm_mul_ps(a, b); }
+inline fvecType fvecFmadd(fvecType a, fvecType b, fvecType c) {
+#if defined(__FMA__)
+    return _mm_fmadd_ps(a, b, c);
+#else
+    return _mm_add_ps(_mm_mul_ps(a, b), c);
+#endif
+}
+inline fvecType fvecMin(fvecType a, fvecType b) { return _mm_min_ps(a, b); }
+inline fvecType fvecMax(fvecType a, fvecType b) { return _mm_max_ps(a, b); }
+inline float fvecReduceAdd(fvecType v) {
+    v = _mm_add_ps(v, _mm_movehl_ps(v, v));
+    v = _mm_add_ss(v, _mm_shuffle_ps(v, v, 1));
+    return _mm_cvtss_f32(v);
+}
+inline vecType vecDpbusdEpi32(vecType acc, vecType a, vecType b) {
+#if defined(__SSSE3__)
+    return _mm_add_epi32(acc, _mm_madd_epi16(_mm_maddubs_epi16(a, b), _mm_set1_epi16(1)));
+#else
+    // SSE2: widen to int16, madd gives two products per lane, the shuffle pair
+    // folds adjacent lanes into the four a dpbusd lane is defined as.
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i sign = _mm_cmpgt_epi8(zero, b);
+    const __m128i lo   = _mm_madd_epi16(_mm_unpacklo_epi8(a, zero), _mm_unpacklo_epi8(b, sign));
+    const __m128i hi   = _mm_madd_epi16(_mm_unpackhi_epi8(a, zero), _mm_unpackhi_epi8(b, sign));
+    const __m128 lops = _mm_castsi128_ps(lo), hips = _mm_castsi128_ps(hi);
+    const __m128i even = _mm_castps_si128(_mm_shuffle_ps(lops, hips, _MM_SHUFFLE(2, 0, 2, 0)));
+    const __m128i odd  = _mm_castps_si128(_mm_shuffle_ps(lops, hips, _MM_SHUFFLE(3, 1, 3, 1)));
+    return _mm_add_epi32(acc, _mm_add_epi32(even, odd));
+#endif
 }
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -178,7 +178,6 @@ enum RankMask : uint64_t {
     RANK_8_BB = RANK_1_BB << 56,
 };
 
-
 constexpr uint64_t DEFAULT_CHECKMASK = 0xFFFFFFFFFFFFFFFFULL;
 
 constexpr char const* SQUARE_IDENTIFIER[]{"a1", "b1", "c1", "d1", "e1", "f1", "g1", "h1", "a2", "b2", "c2", "d2", "e2", "f2", "g2", "h2", "a3", "b3", "c3", "d3", "e3", "f3",
@@ -247,7 +246,6 @@ struct __attribute__((__packed__)) TTBucket {
     uint32_t padding{};
 };
 
-
 struct nnueChange {
     int8_t piece;
     int8_t sq;
@@ -261,73 +259,89 @@ struct nnueChange {
 
 using PieceTo = int16_t[N_PIECES][N_SQUARES];
 
-// One sparse index space: 12*768 king-bucketed piece-square features followed
-// by 96*95/2 pawn pairs. NNUE_FT_OUT must match the trainer's FT constant in
-constexpr int NNUE_FT_IN = 12 * 768 + 96 * 95 / 2;  // 13776
-constexpr int NNUE_FT_OUT = 1024;
+/// Feature-transformer width. Lives here because NNUEAccumulator is sized by it;
+/// the rest of the architecture is described in nnue.h.
+constexpr int NNUE_FT_OUT = 768;
+
+struct DirtyThreat {
+    uint8_t p;
+    uint8_t target;
+    uint8_t sq;
+    uint8_t dest;
+
+    DirtyThreat() = default;
+    DirtyThreat(uint8_t _piece, uint8_t _pieceColor, uint8_t _targetPiece, uint8_t _targetColor, uint8_t _sq, uint8_t _dest, int8_t _sign)
+        : p(static_cast<uint8_t>((_piece & 7) | ((_pieceColor & 1) << 3) | ((_sign > 0 ? 0 : 1) << 4))),
+          target(static_cast<uint8_t>((_targetPiece & 7) | ((_targetColor & 1) << 3))),
+          sq(_sq),
+          dest(_dest) {}
+
+    inline int piece() const { return p & 7; }
+    inline int pieceColor() const { return (p >> 3) & 1; }
+    inline int sign() const { return (p & 16) ? -1 : 1; }
+    inline int targetPiece() const { return target & 7; }
+    inline int targetColor() const { return (target >> 3) & 1; }
+};
 
 struct NNUEAccumulator {
-    alignas(64) int16_t data[2][NNUE_FT_OUT]{};
+    // Split because a psq index depends on bucket AND mirror while a tac index
+    // depends on the mirror alone: 90% of bucket changes rebuild psq only.
+    alignas(64) int16_t psq[2][NNUE_FT_OUT]{};
+    alignas(64) int16_t tac[2][NNUE_FT_OUT]{};  // includes the FT bias
 
     // Board state AFTER this ply, needed by the incremental update and filled
-    // by `Board::makeMove`. The pawn bitboards drive the pawn-pair delta, and
-    // the king squares decide whether a perspective can be updated at all: a
-    // king that crosses a bucket or mirror boundary re-indexes every psq
-    // feature and forces that perspective to be rebuilt.
+    // by `Board::makeMove`.
     uint64_t pawns[N_COLORS]{};
     uint8_t  kingSq[N_COLORS]{};
     bool     stateValid{};
 
     nnueChange changes[4]{};
     uint8_t changeCount{};
-    // Per perspective, because one side's king can force a rebuild while the
-    // other side's accumulator stays incrementally reachable.
-    bool computed[N_COLORS]{};
+
+    DirtyThreat threatChanges[64]{};
+    uint8_t threatChangeCount{};
+
+    bool computedPsq[N_COLORS]{};
+    bool computedTac[N_COLORS]{};
 
     void clear() {
-        computed[WHITE] = computed[BLACK] = false;
-        stateValid      = false;
-        changeCount     = 0;
+        computedPsq[WHITE] = computedPsq[BLACK] = false;
+        computedTac[WHITE] = computedTac[BLACK] = false;
+        stateValid         = false;
+        changeCount        = 0;
+        threatChangeCount  = 0;
     }
-
-    void invalidate() { clear(); }
-
-    void clearChanges() { changeCount = 0; }
 
     void addChange(int piece, int sq, int sign) {
         if (changeCount < 4)
             changes[changeCount++] = {piece, sq, sign};
     }
+
+    inline void addThreatChange(int piece, int pieceColor, int targetPiece, int targetColor, int sq, int dest, int sign) {
+        if (targetPiece == KING) return;
+        if (piece == PAWN && targetPiece != KNIGHT && targetPiece != ROOK) return;
+        if ((piece == BISHOP || piece == ROOK) && targetPiece == QUEEN) return;
+        if (threatChangeCount < 64)
+            threatChanges[threatChangeCount++] = {
+                static_cast<uint8_t>(piece),
+                static_cast<uint8_t>(pieceColor),
+                static_cast<uint8_t>(targetPiece),
+                static_cast<uint8_t>(targetColor),
+                static_cast<uint8_t>(sq),
+                static_cast<uint8_t>(dest),
+                static_cast<int8_t>(sign)
+            };
+    }
 };
 
 static_assert(alignof(NNUEAccumulator) == 64, "simd.h issues aligned loads on NNUEAccumulator::data");
 
-/// One cached accumulator per (perspective, king bucket, mirror), together with
-/// the piece placement it was built from. A king that changes bucket cannot be
-/// updated with deltas, but it can be rebuilt as a delta from the last position
-/// that used the SAME bucket instead of from the bias, which is normally a
-/// handful of rows rather than all ~68.
-struct NNUERefreshEntry {
-    alignas(64) int16_t data[NNUE_FT_OUT]{};
-    uint64_t pieces[N_PIECES]{};
-    bool     initialised{};
-};
-
 class NNUEData {
    public:
-    static constexpr int REFRESH_BUCKETS = 12;
-    static constexpr int REFRESH_ENTRIES = N_COLORS * REFRESH_BUCKETS * 2;  // x2 for the mirror
+    std::vector<NNUEAccumulator> accumulator;
+    int                          size{};
 
-    std::vector<NNUEAccumulator>  accumulator;
-    std::vector<NNUERefreshEntry> refreshCache;
-    int                           size{};
-
-    NNUEData() : accumulator(MAX_PLY + 10), refreshCache(REFRESH_ENTRIES) {}
-
-    void clearRefreshCache() {
-        for (auto& entry : refreshCache)
-            entry.initialised = false;
-    }
+    NNUEData() : accumulator(MAX_PLY + 10) {}
 };
 
 struct BoardHistory {

--- a/src/types.h
+++ b/src/types.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 #ifndef VERSION
-    #define VERSION "7.07"
+    #define VERSION "7.08"
 #endif
 
 constexpr auto MAX_PLY   = 100;

--- a/src/types.h
+++ b/src/types.h
@@ -19,11 +19,8 @@
 constexpr auto MAX_PLY   = 100;
 constexpr auto START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-// Internal eval units per reported pawn. Fitted on 3.2M positions from 37836
-// self-play games: a position worth this much internally is won half the time,
-// so "score cp 100" means a 50% win probability, as in Stockfish. Only the
-// reported score is scaled; search and datagen keep the internal units.
-constexpr int NORMALIZE_TO_PAWN = 325;
+// "score cp 100" means a 50% win probability, as in Stockfish.
+constexpr int NORMALIZE_TO_PAWN = 290;
 
 enum Score : int16_t {
     MAX_MATE_SCORE = 32000,
@@ -283,7 +280,22 @@ struct DirtyThreat {
     inline int targetColor() const { return (target >> 3) & 1; }
 };
 
+/// Victim types each attacker can threaten; checked against the index tables
+/// in nnue.cpp, which are the trainer's feature space.
+constexpr uint8_t THREAT_VICTIMS[N_PIECE_TYPES] = {
+    (1 << KNIGHT) | (1 << ROOK),                                               // PAWN
+    (1 << PAWN) | (1 << KNIGHT) | (1 << BISHOP) | (1 << ROOK) | (1 << QUEEN),  // KNIGHT
+    (1 << PAWN) | (1 << KNIGHT) | (1 << BISHOP) | (1 << ROOK),                 // BISHOP
+    (1 << PAWN) | (1 << KNIGHT) | (1 << BISHOP) | (1 << ROOK),                 // ROOK
+    (1 << PAWN) | (1 << KNIGHT) | (1 << BISHOP) | (1 << ROOK) | (1 << QUEEN),  // QUEEN
+    0,                                                                         // KING
+};
+
 struct NNUEAccumulator {
+    // A move touches at most 3 non-king squares, each worth at most 36 changes
+    // (28 attackers plus 8 discovered), so this cannot overflow.
+    static constexpr int MAX_THREAT_CHANGES = 128;
+
     // Split because a psq index depends on bucket AND mirror while a tac index
     // depends on the mirror alone: 90% of bucket changes rebuild psq only.
     alignas(64) int16_t psq[2][NNUE_FT_OUT]{};
@@ -298,8 +310,8 @@ struct NNUEAccumulator {
     nnueChange changes[4]{};
     uint8_t changeCount{};
 
-    DirtyThreat threatChanges[64]{};
-    uint8_t threatChangeCount{};
+    DirtyThreat threatChanges[MAX_THREAT_CHANGES]{};
+    uint8_t     threatChangeCount{};
 
     bool computedPsq[N_COLORS]{};
     bool computedTac[N_COLORS]{};
@@ -318,10 +330,8 @@ struct NNUEAccumulator {
     }
 
     inline void addThreatChange(int piece, int pieceColor, int targetPiece, int targetColor, int sq, int dest, int sign) {
-        if (targetPiece == KING) return;
-        if (piece == PAWN && targetPiece != KNIGHT && targetPiece != ROOK) return;
-        if ((piece == BISHOP || piece == ROOK) && targetPiece == QUEEN) return;
-        if (threatChangeCount < 64)
+        if (!((THREAT_VICTIMS[piece] >> targetPiece) & 1)) return;
+        if (threatChangeCount < MAX_THREAT_CHANGES)
             threatChanges[threatChangeCount++] = {
                 static_cast<uint8_t>(piece),
                 static_cast<uint8_t>(pieceColor),
@@ -334,7 +344,7 @@ struct NNUEAccumulator {
     }
 };
 
-static_assert(alignof(NNUEAccumulator) == 64, "simd.h issues aligned loads on NNUEAccumulator::data");
+static_assert(alignof(NNUEAccumulator) == 64, "simd.h issues aligned loads on NNUEAccumulator::psq/tac");
 
 class NNUEData {
    public:

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -212,8 +212,6 @@ void Uci::setoption(std::vector<std::string>& commands) {
             {
                 board->nnueData.size = 0;
                 board->nnueData.accumulator[0].clear();
-                // The cached refresh accumulators belong to the old weights.
-                board->nnueData.clearRefreshCache();
             }
         }
         return;


### PR DESCRIPTION
Threat Net: the feature transformer now takes three input blocks instead of two
768×12 king-bucketed psq, 4560 pawn-pair features, and 59808 threat features:
73584 inputs into 768, then pairwise → 16 → 32 → 1. 
Output buckets are also removed in this version

The net is trained with [bullet](https://github.com/jw1912/bullet)

Inference and Architecture is inspired by [PlentyChess](https://github.com/Yoshie2000/PlentyChess) and [Stockfish](https://github.com/official-stockfish/Stockfish) 

Passed LTC SPRT

```
Elo   | 30.60 +- 7.40 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 1958 W: 570 L: 398 D: 990
Penta | [0, 148, 514, 314, 3]
```

